### PR TITLE
Implement media file linking with folder management and season display

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,6 @@
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at `specs/006-app-enhancements/plan.md`
+at `specs/007-media-file-linking/plan.md`
 
 <!-- SPECKIT END -->

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/006-app-enhancements"
+  "feature_directory": "specs/007-media-file-linking"
 }

--- a/specs/007-media-file-linking/checklists/requirements.md
+++ b/specs/007-media-file-linking/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Media File Linking & Missing Content Detection
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.
+- The Assumptions section documents known API details (endpoints, entity fields) observed from the existing codebase; these are implementation constraints, not requirements, and are deliberately kept in the Assumptions section rather than the Requirements section.

--- a/specs/007-media-file-linking/contracts/api-contracts.md
+++ b/specs/007-media-file-linking/contracts/api-contracts.md
@@ -1,0 +1,266 @@
+# API Contracts: Media File Linking & Missing Content Detection
+
+**Feature**: 007-media-file-linking  
+**Date**: 2026-05-21  
+**Base URL**: `/api/v1`
+
+---
+
+## New Endpoints
+
+### 1. GET `/media/{id}/completeness`
+
+**Controller**: `MediaController` (existing, `[Authorize]`)  
+**Purpose**: Returns per-season completeness data for a TV show. Films return 400.
+
+**Request**
+
+```
+GET /api/v1/media/{id}/completeness
+Authorization: Bearer <token>
+```
+
+| Parameter | Type   | Location | Required | Description     |
+| --------- | ------ | -------- | -------- | --------------- |
+| `id`      | `Guid` | path     | ✅       | Media entity ID |
+
+**Response — 200 OK**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "seasonNumber": 1,
+      "seasonName": "Season 1",
+      "totalExpected": 10,
+      "ownedCount": 8,
+      "missingEpisodeNumbers": [3, 7],
+      "isComplete": false
+    },
+    {
+      "seasonNumber": 2,
+      "seasonName": "Season 2",
+      "totalExpected": 8,
+      "ownedCount": 8,
+      "missingEpisodeNumbers": [],
+      "isComplete": true
+    }
+  ]
+}
+```
+
+**Response — 400 Bad Request** (called on a Film)
+
+```json
+{
+  "success": false,
+  "errors": [
+    { "code": "MEDIA_TYPE_INVALID", "message": "Completeness is only supported for TV shows." }
+  ]
+}
+```
+
+**Response — 404 Not Found**
+
+```json
+{ "success": false, "errors": [{ "code": "NOT_FOUND", "message": "Media 'id' not found." }] }
+```
+
+**Notes**:
+
+- Season 0 and seasons named "Specials" (case-insensitive) are excluded.
+- Empty array returned when the TV show has no enriched `TvSeason` records.
+
+---
+
+### 2. GET `/admin/media/unlinked-files`
+
+**Controller**: `AdminMediaFilesController` (NEW, `[Authorize(Policy = "AdminOnly")]`)  
+**Purpose**: Paginated list of `MediaFile` rows not assigned to any `Media` (i.e., `MediaId IS NULL`).
+
+**Request**
+
+```
+GET /api/v1/admin/media/unlinked-files?page=1&pageSize=20
+Authorization: Bearer <admin-token>
+```
+
+| Parameter  | Type  | Location | Required | Default | Description         |
+| ---------- | ----- | -------- | -------- | ------- | ------------------- |
+| `page`     | `int` | query    | ❌       | 1       | 1-based page number |
+| `pageSize` | `int` | query    | ❌       | 20      | Max 100             |
+
+**Response — 200 OK**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "filePath": "/nas/Movies/Inception (2010)/Inception.mkv",
+      "fileSizeBytes": 8589934592,
+      "format": "mkv",
+      "resolution": "1080p"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "pageSize": 20,
+    "totalCount": 47,
+    "totalPages": 3
+  }
+}
+```
+
+---
+
+### 3. PUT `/admin/media/{mediaId}/files/{fileId}/link`
+
+**Controller**: `AdminMediaFilesController` (NEW, `[Authorize(Policy = "AdminOnly")]`)  
+**Purpose**: Sets `MediaFile.MediaId = mediaId`.
+
+**Request**
+
+```
+PUT /api/v1/admin/media/{mediaId}/files/{fileId}/link
+Authorization: Bearer <admin-token>
+```
+
+| Parameter | Type   | Location | Required | Description            |
+| --------- | ------ | -------- | -------- | ---------------------- |
+| `mediaId` | `Guid` | path     | ✅       | Target Media entity ID |
+| `fileId`  | `Guid` | path     | ✅       | MediaFile entity ID    |
+
+No request body.
+
+**Response — 204 No Content** (success)
+
+**Response — 404 Not Found**
+
+```json
+{ "success": false, "errors": [{ "code": "MEDIA_NOT_FOUND", "message": "Media 'mediaId' not found." }] }
+{ "success": false, "errors": [{ "code": "FILE_NOT_FOUND", "message": "MediaFile 'fileId' not found." }] }
+```
+
+**Response — 422 Unprocessable Entity** (file already linked to another media)
+
+```json
+{
+  "success": false,
+  "errors": [
+    {
+      "code": "FILE_ALREADY_LINKED",
+      "message": "MediaFile 'fileId' is already linked to media 'otherMediaId'."
+    }
+  ]
+}
+```
+
+---
+
+### 4. DELETE `/admin/media/{mediaId}/files/{fileId}/link`
+
+**Controller**: `AdminMediaFilesController` (NEW, `[Authorize(Policy = "AdminOnly")]`)  
+**Purpose**: Clears `MediaFile.MediaId` (sets to `null`).
+
+**Request**
+
+```
+DELETE /api/v1/admin/media/{mediaId}/files/{fileId}/link
+Authorization: Bearer <admin-token>
+```
+
+| Parameter | Type   | Location | Required | Description            |
+| --------- | ------ | -------- | -------- | ---------------------- |
+| `mediaId` | `Guid` | path     | ✅       | Target Media entity ID |
+| `fileId`  | `Guid` | path     | ✅       | MediaFile entity ID    |
+
+No request body.
+
+**Response — 204 No Content** (success)
+
+**Response — 404 Not Found**
+
+```json
+{
+  "success": false,
+  "errors": [
+    {
+      "code": "FILE_NOT_FOUND",
+      "message": "MediaFile 'fileId' not found or not linked to this media."
+    }
+  ]
+}
+```
+
+---
+
+### 5. PATCH `/admin/media/{mediaId}/root-folder`
+
+**Controller**: `AdminMediaFilesController` (NEW, `[Authorize(Policy = "AdminOnly")]`)  
+**Purpose**: Set or clear the manual root folder override on a `Media` item.
+
+**Request**
+
+```
+PATCH /api/v1/admin/media/{mediaId}/root-folder
+Content-Type: application/json
+Authorization: Bearer <admin-token>
+
+{
+  "rootFolder": "/nas/TV Shows/Breaking Bad"
+}
+```
+
+| Body field   | Type             | Required | Description                                                              |
+| ------------ | ---------------- | -------- | ------------------------------------------------------------------------ |
+| `rootFolder` | `string \| null` | ✅       | New root folder path. Send `null` or empty string to clear the override. |
+
+**Response — 204 No Content** (success)
+
+**Response — 404 Not Found**
+
+```json
+{ "success": false, "errors": [{ "code": "NOT_FOUND", "message": "Media 'mediaId' not found." }] }
+```
+
+---
+
+## Modified Endpoints
+
+### GET `/media/{id}` (MODIFIED)
+
+`MediaDto` gains one new field:
+
+```json
+{
+  "id": "...",
+  "title": "Breaking Bad",
+  // ...existing fields...
+  "rootFolder": "/nas/TV Shows/Breaking Bad" // NEW — null if no files and no override
+}
+```
+
+The `rootFolder` value is resolved server-side:
+
+1. If `Media.RootFolder` is set → return that value.
+2. Else if linked files exist → return the common parent directory of all `MediaFile.FilePath` values.
+3. Else → `null`.
+
+---
+
+## Unchanged Endpoints (No Backend Modification Needed)
+
+### GET `/admin/parent-folders` (UNCHANGED)
+
+The existing endpoint already supports `status=Assigned` (pending import only) and `status=InCollection` (fully in collection) as separate filter values. Only the **frontend i18n label** changes:
+
+| i18n key                             | Old value (EN) | New value (EN)                     |
+| ------------------------------------ | -------------- | ---------------------------------- |
+| `admin.parentFolders.statusAssigned` | `"Assigned"`   | `"TMDB Assigned (Pending Import)"` |
+
+| i18n key                             | Old value (FR) | New value (FR)                       |
+| ------------------------------------ | -------------- | ------------------------------------ |
+| `admin.parentFolders.statusAssigned` | `"Assigné"`    | `"TMDB assigné (import en attente)"` |

--- a/specs/007-media-file-linking/data-model.md
+++ b/specs/007-media-file-linking/data-model.md
@@ -1,0 +1,202 @@
+# Data Model: Media File Linking & Missing Content Detection
+
+**Feature**: 007-media-file-linking  
+**Date**: 2026-05-21
+
+---
+
+## Backend Entity Changes
+
+### `Media` (MODIFIED)
+
+New column: `RootFolder string? (nullable text)`.
+
+```csharp
+// MediaHandler.Domain/Entities/Media.cs — new property
+/// <summary>
+///     Manually set root folder path on the NAS for this media item.
+///     When null the effective root folder is auto-derived at read time
+///     from the common parent directory of all linked MediaFile.FilePath values.
+/// </summary>
+public string? RootFolder { get; set; }
+```
+
+EF Core configuration (`MediaConfiguration.cs`):
+
+```csharp
+builder.Property(m => m.RootFolder)
+    .HasColumnName("root_folder")
+    .HasColumnType("text")
+    .IsRequired(false);
+```
+
+EF migration: `AddMediaRootFolder` — single `AlterTable` adding `root_folder text NULL`.
+
+---
+
+## New DTOs (Backend)
+
+### `MediaDto` (MODIFIED)
+
+Add `RootFolder` field:
+
+```csharp
+// MediaHandler.Application/Features/Media/DTOs/MediaDto.cs
+public record MediaDto(
+    // ...existing fields...
+    string? RootFolder          // effective = stored override ?? computed common-parent
+);
+```
+
+### `SeasonCompletenessDto` (NEW)
+
+```csharp
+// MediaHandler.Application/Features/Media/DTOs/SeasonCompletenessDto.cs
+namespace MediaHandler.Application.Features.Media.DTOs;
+
+public record SeasonCompletenessDto(
+    int SeasonNumber,
+    string SeasonName,
+    int TotalExpected,      // TvSeason.EpisodeCount ?? TvEpisodes.Count
+    int OwnedCount,         // episodes with at least one EpisodeFileLink
+    IReadOnlyList<int> MissingEpisodeNumbers,
+    bool IsComplete
+);
+```
+
+### `UnlinkedFileDto` (NEW)
+
+```csharp
+// MediaHandler.Application/Features/Files/Queries/GetUnlinkedFiles/UnlinkedFileDto.cs
+namespace MediaHandler.Application.Features.Files.Queries.GetUnlinkedFiles;
+
+public record UnlinkedFileDto(
+    Guid Id,
+    string FilePath,
+    long? FileSizeBytes,
+    string? Format,
+    string? Resolution
+);
+```
+
+---
+
+## New MediatR Queries & Commands (Backend)
+
+| Type    | Name                           | Input                              | Output                                         |
+| ------- | ------------------------------ | ---------------------------------- | ---------------------------------------------- |
+| Query   | `GetMediaCompletenessQuery`    | `Guid MediaId`                     | `Result<IReadOnlyList<SeasonCompletenessDto>>` |
+| Query   | `GetUnlinkedFilesQuery`        | `int Page, int PageSize`           | `Result<PagedResult<UnlinkedFileDto>>`         |
+| Command | `LinkMediaFileCommand`         | `Guid MediaId, Guid FileId`        | `Result<Unit>`                                 |
+| Command | `UnlinkMediaFileCommand`       | `Guid MediaId, Guid FileId`        | `Result<Unit>`                                 |
+| Command | `UpdateMediaRootFolderCommand` | `Guid MediaId, string? RootFolder` | `Result<Unit>`                                 |
+
+---
+
+## Frontend Model Changes
+
+### `media.model.ts` (MODIFIED)
+
+```typescript
+// Existing Media interface — add:
+export interface Media {
+  // ...existing fields...
+  /** Effective root folder (manual override or auto-derived by API) */
+  rootFolder: string | null;
+}
+
+// New type for completeness panel
+export interface SeasonCompleteness {
+  seasonNumber: number;
+  seasonName: string;
+  totalExpected: number;
+  ownedCount: number;
+  missingEpisodeNumbers: number[];
+  isComplete: boolean;
+}
+```
+
+---
+
+## Frontend New Services
+
+### `AdminMediaFileLinkService` (NEW)
+
+Location: `src/app/core/services/admin-media-file-link.service.ts`
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class AdminMediaFileLinkService {
+  // Signals
+  readonly unlinkedFiles = signal<UnlinkedFile[]>([]);
+  readonly unlinkedFilesMeta = signal<PaginationMeta | null>(null);
+  readonly unlinkedFilesLoading = signal(false);
+
+  // Methods
+  getUnlinkedFiles(page: number, pageSize: number): void {
+    /* ... */
+  }
+  linkFile(mediaId: string, fileId: string): Observable<void> {
+    /* ... */
+  }
+  unlinkFile(mediaId: string, fileId: string): Observable<void> {
+    /* ... */
+  }
+  updateRootFolder(mediaId: string, rootFolder: string | null): Observable<void> {
+    /* ... */
+  }
+}
+```
+
+### `MediaDetailService` (MODIFIED)
+
+New methods appended:
+
+```typescript
+// Add to existing MediaDetailService
+readonly completeness = signal<SeasonCompleteness[]>([]);
+readonly completenessLoading = signal(false);
+readonly completenessError = signal<string | null>(null);
+
+loadCompleteness(mediaId: string): void { /* GET /media/{id}/completeness */ }
+```
+
+Link/unlink delegate to `AdminMediaFileLinkService` then call `loadMedia(id)` to refresh.
+
+---
+
+## State Transitions
+
+### MediaFile.MediaId
+
+```
+null (unlinked)
+  ─── link(mediaId) ──► mediaId (linked)
+  ◄── unlink() ────────
+```
+
+### Media.RootFolder
+
+```
+null (no override, auto-derived)
+  ─── updateRootFolder(path) ──► "path" (manual override)
+  ─── updateRootFolder(null) ──► null (clear override)
+```
+
+---
+
+## Completeness Derivation Logic
+
+```
+for each TvSeason where SeasonNumber > 0 AND NOT name contains "specials":
+  ownedEps  = episodes.filter(e => e.episodeFileLinks.length > 0).map(e => e.episodeNumber)
+  totalEps  = season.episodeCount ?? episodes.length
+  missing   = [1..totalEps] - ownedEps     (set difference)
+  isComplete = missing.length == 0
+```
+
+Edge cases:
+
+- `TvSeason.EpisodeCount` is null → use `TvEpisodes.Count` as denominator.
+- No TvSeasons enriched → return empty list; frontend shows "Metadata not available".
+- Film media type → endpoint returns 400 Bad Request; frontend does not call it.

--- a/specs/007-media-file-linking/plan.md
+++ b/specs/007-media-file-linking/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Media File Linking & Missing Content Detection
+
+**Branch**: `develop` | **Date**: 2026-05-21 | **Spec**: [specs/007-media-file-linking/spec.md](./spec.md)  
+**Input**: Feature specification from `specs/007-media-file-linking/spec.md`
+
+## Summary
+
+Extend the MediaHandler application with four capabilities:
+
+1. **File Linking from Detail Page** — Allow admins to link/unlink `MediaFile` records to a `Media` item directly from the detail page (new `PUT`/`DELETE` admin endpoints; modified `MediaFilesComponent` with link picker dialog).
+2. **Root Folder** — Store a `RootFolder` path on each `Media` entity (auto-derived from linked files or manually set); display it on the detail page with a clipboard-copy action.
+3. **Season Completeness** — Display a read-only completeness panel on TV-show detail pages listing owned vs. expected episodes per season (season 1+), derived from the existing `EpisodeFileLink` join table via a new `GET /api/v1/media/{id}/completeness` endpoint.
+4. **Parent-Folder Status-Filter Label Clarification** — Rename the "Assigned" filter label to "TMDB Assigned (Pending Import)" in both i18n files so the scan-results admin knows it covers only entries awaiting import — no backend filtering change needed because the API already separates `Assigned` and `InCollection`.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x / Angular 21 (frontend); C# 12 / .NET 10 (backend — `MediaHandler.API` repo)  
+**Primary Dependencies**: PrimeNG 17+ (`p-dialog`, `p-table`, `p-button`, `p-tag`), Transloco 7+, Angular Signals, MediatR 12, EF Core 9, PostgreSQL  
+**Storage**: PostgreSQL via EF Core; `Media.RootFolder` stored as `text` (nullable)  
+**Testing**: Vitest + Angular Testing Library (frontend); xUnit (backend — companion)  
+**Target Platform**: Modern evergreen browsers; Angular SPA served from .NET Kestrel/Nginx  
+**Project Type**: Web application — Angular standalone-component SPA + .NET 10 REST API (separate repo)  
+**Performance Goals**: Completeness panel loads ≤ 2 s; link/unlink action reflects in list ≤ 1 s; initial bundle ≤ 500 kB warning / 1 MB error  
+**Constraints**: `OnPush` CD required; standalone components only; no NgModules; `any` forbidden; signals-first state; `DestroyRef`/`takeUntilDestroyed()` for streams  
+**Scale/Scope**: Personal/small-team library; up to ~10 k `MediaFile` rows; paginated unlinked-file picker (20/page default)
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design._
+
+| Principle                             | Requirement                                             | Status  | Notes                                                                                                                    |
+| ------------------------------------- | ------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Single Responsibility (≤200 lines)    | Components exceeding 200 lines must be refactored       | ✅ PASS | `RootFolderComponent`, `SeasonCompletenessComponent`, `FileLinkPickerDialogComponent` are separate standalone components |
+| Angular Signals-First                 | New state must use signals                              | ✅ PASS | All new state in services uses `signal()`; HTTP calls via `toSignal()` or `async` pipe                                   |
+| Strict Typing                         | TypeScript strict mode; no `any`; explicit return types | ✅ PASS | All new DTOs/interfaces fully typed                                                                                      |
+| Standalone Components                 | All new components must be standalone                   | ✅ PASS | No NgModules introduced                                                                                                  |
+| Reactive Patterns                     | No manual subscriptions; use `async` or `toSignal()`    | ✅ PASS | All HTTP: `toSignal()` or `finalize()`+subscribe bound to `DestroyRef`                                                   |
+| Unit Tests Required (≥80% statements) | Vitest tests for every new service/pipe/component       | ✅ PASS | Tests planned per task                                                                                                   |
+| OnPush Change Detection               | All new components must use `OnPush`                    | ✅ PASS | Enforced by lint rule                                                                                                    |
+| NgOptimizedImage                      | No unoptimized `<img>`                                  | ✅ PASS | No new `<img>` tags in this feature                                                                                      |
+| Bundle Budget                         | No budget relaxation                                    | ✅ PASS | No new third-party packages; PrimeNG dialog/table already in bundle                                                      |
+| Memory Management                     | `DestroyRef`/`takeUntilDestroyed()`                     | ✅ PASS | Used in all new components with subscriptions                                                                            |
+| Responsive Design (360–2560 px)       | Mobile-first SCSS                                       | ✅ PASS | Completeness panel and file-linking dialog use responsive grid                                                           |
+| Consistent Styling                    | SCSS variables/mixins; no hardcoded values              | ✅ PASS | Existing `_variables.scss` tokens used throughout                                                                        |
+
+**Gate result**: ✅ No violations — proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-media-file-linking/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output — entity/DTO changes + new frontend types
+├── quickstart.md        # Phase 1 output — setup & verification checklist
+├── contracts/
+│   └── api-contracts.md # Phase 1 output — all new/modified endpoints
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+# Frontend — MediaHandler.Web (Angular SPA)
+src/app/
+├── features/
+│   ├── media-detail/
+│   │   ├── media-detail.service.ts           # MODIFIED: +linkFile(), +unlinkFile(), +updateRootFolder(), +loadCompleteness()
+│   │   ├── media-files.component.ts          # MODIFIED: +unlink button; admin-only link-picker trigger
+│   │   ├── media-files.component.html        # MODIFIED
+│   │   ├── root-folder.component.ts          # NEW: displays root folder path, copy + manual edit (admin-only)
+│   │   ├── root-folder.component.html        # NEW
+│   │   ├── root-folder.component.scss        # NEW
+│   │   ├── root-folder.component.spec.ts     # NEW
+│   │   ├── file-link-picker-dialog.component.ts   # NEW: paginated list of unlinked files, link action
+│   │   ├── file-link-picker-dialog.component.html # NEW
+│   │   ├── file-link-picker-dialog.component.scss # NEW
+│   │   ├── file-link-picker-dialog.component.spec.ts # NEW
+│   │   ├── season-completeness.component.ts  # NEW: completeness panel for TV shows
+│   │   ├── season-completeness.component.html # NEW
+│   │   ├── season-completeness.component.scss # NEW
+│   │   ├── season-completeness.component.spec.ts # NEW
+│   │   └── media-detail-page.component.ts    # MODIFIED: wire new child components
+│   └── admin/
+│       ├── parent-folders/
+│       │   └── admin-parent-folders-page.component.ts  # MINOR: label clarity (i18n key rename)
+│       └── shared/
+│           └── (no changes)
+├── core/
+│   └── services/
+│       └── admin-media-file-link.service.ts  # NEW: link/unlink/unlinked-files/root-folder API calls
+└── shared/
+    └── models/
+        └── media.model.ts                    # MODIFIED: +rootFolder, +completeness types
+    i18n/
+        ├── en.json                           # MODIFIED: +mediaDetail.* keys, rename parentFolders.statusAssigned label
+        └── fr.json                           # MODIFIED: same
+
+# Backend — MediaHandler.API (companion changes)
+MediaHandler.Domain/Entities/
+└── Media.cs                                  # MODIFIED: +RootFolder (string?)
+
+MediaHandler.Infrastructure/Persistence/
+├── Configurations/
+│   └── MediaConfiguration.cs                 # MODIFIED: map RootFolder column
+└── Migrations/
+    └── AddMediaRootFolder.cs                 # NEW: EF Core migration
+
+MediaHandler.Application/Features/Media/
+├── DTOs/
+│   ├── MediaDto.cs                           # MODIFIED: +RootFolder field
+│   └── SeasonCompletenessDto.cs              # NEW: completeness DTO
+├── Queries/
+│   └── GetMediaCompleteness/
+│       └── GetMediaCompletenessQueryHandler.cs # NEW
+└── Commands/
+    ├── LinkMediaFile/
+    │   └── LinkMediaFileCommandHandler.cs    # NEW
+    ├── UnlinkMediaFile/
+    │   └── UnlinkMediaFileCommandHandler.cs  # NEW
+    └── UpdateMediaRootFolder/
+        └── UpdateMediaRootFolderCommandHandler.cs # NEW
+
+MediaHandler.Application/Features/Files/Queries/
+└── GetUnlinkedFiles/
+    └── GetUnlinkedFilesQueryHandler.cs       # NEW
+
+MediaHandler.API/Controllers/
+├── MediaController.cs                        # MODIFIED: +GET completeness endpoint
+└── AdminMediaFilesController.cs              # NEW: link/unlink/root-folder + unlinked-files list
+```
+
+**Structure Decision**: Web application (Option 2). Frontend in `MediaHandler.Web/src/`. Backend companion changes tracked in `MediaHandler.API`. All state for new operations uses Angular signals. No new third-party packages required.
+
+## Complexity Tracking
+
+_No constitution violations — table not applicable._

--- a/specs/007-media-file-linking/quickstart.md
+++ b/specs/007-media-file-linking/quickstart.md
@@ -1,0 +1,157 @@
+# Quickstart: Media File Linking & Missing Content Detection
+
+**Feature**: 007-media-file-linking  
+**Date**: 2026-05-21
+
+---
+
+## Prerequisites
+
+- .NET 10 SDK + PostgreSQL running locally
+- Node.js 22+ with `npm` (or `pnpm`)
+- Both repos cloned side-by-side:
+  - `MediaHandler.API/`
+  - `MediaHandler.Web/`
+
+---
+
+## Backend Setup (MediaHandler.API)
+
+### 1. Apply EF Core Migration
+
+```bash
+cd MediaHandler.API
+dotnet ef migrations add AddMediaRootFolder \
+  --project MediaHandler.Infrastructure \
+  --startup-project MediaHandler.API
+
+dotnet ef database update \
+  --project MediaHandler.Infrastructure \
+  --startup-project MediaHandler.API
+```
+
+**Verify**: New column `root_folder text NULL` exists in the `Medias` table.
+
+### 2. Build & Run API
+
+```bash
+dotnet build
+dotnet run --project MediaHandler.API
+# API starts at https://localhost:7001 (or configured port)
+```
+
+### 3. Verify New Endpoints
+
+Using curl or Swagger UI (`/swagger`):
+
+```bash
+# Get completeness for a known TV show ID
+curl -H "Authorization: Bearer <token>" \
+     https://localhost:7001/api/v1/media/<tvShowId>/completeness
+
+# Expected: array of SeasonCompletenessDto (empty array if no TvSeason data)
+
+# List unlinked files (admin token required)
+curl -H "Authorization: Bearer <admin-token>" \
+     "https://localhost:7001/api/v1/admin/media/unlinked-files?page=1&pageSize=5"
+
+# Expected: paginated list of MediaFile rows with MediaId == null
+```
+
+---
+
+## Frontend Setup (MediaHandler.Web)
+
+### 1. Install Dependencies
+
+No new packages required. Existing PrimeNG, Transloco, and Angular are sufficient.
+
+```bash
+cd MediaHandler.Web
+npm install   # or: pnpm install
+```
+
+### 2. Generate Environment
+
+```bash
+node scripts/generate-env.mjs
+```
+
+### 3. Run Dev Server
+
+```bash
+npm start
+# App available at http://localhost:4200
+```
+
+---
+
+## Verification Checklist
+
+### US1 — File Linking from Detail Page
+
+- [ ] Navigate to any TV show or film detail page as **admin**.
+- [ ] Confirm the "Files" section shows existing linked files with an "Unlink" button per file.
+- [ ] Click "Link File" → dialog opens with paginated list of unlinked files.
+- [ ] Select a file and click "Link" → file appears in the list; dialog closes.
+- [ ] Click "Unlink" on a file → file disappears from list.
+- [ ] Navigate as **non-admin** user → confirm "Unlink" and "Link File" buttons are NOT visible.
+
+### US2 — Root Folder
+
+- [ ] Detail page shows "Root Folder" section with auto-derived path (from linked files).
+- [ ] Click "Open in explorer" → path is copied to clipboard (toast confirms).
+- [ ] Block clipboard access in browser settings → fallback text field appears with path.
+- [ ] Edit the root folder path and save → change persists across page reload.
+- [ ] Unset the override (clear field, save) → auto-derived path is shown again.
+- [ ] Media item with no files → "No root folder" empty state is shown.
+
+### US3 — Season Completeness
+
+- [ ] TV show detail page shows "Completeness" section.
+- [ ] Season 0 is NOT listed.
+- [ ] Seasons with all episodes owned show a ✅ "Complete" badge.
+- [ ] Seasons with missing episodes list the specific missing episode numbers.
+- [ ] TV show with no TvSeason data → "Metadata not available" message shown.
+- [ ] Film detail page → NO "Completeness" section present.
+
+### US4 — Parent Folder Filter Label
+
+- [ ] Navigate to Admin → Parent Folders page.
+- [ ] The filter dropdown shows "TMDB Assigned (Pending Import)" (EN) / "TMDB assigné (import en attente)" (FR).
+- [ ] Selecting this filter returns only folders with `status=Assigned` (not InCollection).
+- [ ] "In Collection" filter still works correctly.
+
+---
+
+## Running Tests
+
+### Frontend (Vitest)
+
+```bash
+cd MediaHandler.Web
+npm test
+# or: npx vitest run
+```
+
+New test files to verify pass:
+
+- `src/app/features/media-detail/root-folder.component.spec.ts`
+- `src/app/features/media-detail/file-link-picker-dialog.component.spec.ts`
+- `src/app/features/media-detail/season-completeness.component.spec.ts`
+- `src/app/core/services/admin-media-file-link.service.spec.ts`
+
+### Backend (xUnit)
+
+```bash
+cd MediaHandler.API
+dotnet test
+```
+
+New test files to verify pass:
+
+- `MediaHandler.Tests/Features/Media/GetMediaCompletenessQueryHandlerTests.cs`
+- `MediaHandler.Tests/Features/Media/LinkMediaFileCommandHandlerTests.cs`
+- `MediaHandler.Tests/Features/Media/UnlinkMediaFileCommandHandlerTests.cs`
+- `MediaHandler.Tests/Features/Media/UpdateMediaRootFolderCommandHandlerTests.cs`
+- `MediaHandler.Tests/Features/Files/GetUnlinkedFilesQueryHandlerTests.cs`

--- a/specs/007-media-file-linking/research.md
+++ b/specs/007-media-file-linking/research.md
@@ -1,0 +1,124 @@
+# Research: Media File Linking & Missing Content Detection
+
+**Feature**: 007-media-file-linking  
+**Date**: 2026-05-21  
+**Phase**: 0 — Outline & Research
+
+---
+
+## R-001 — File Linking Architecture: MediaFile ↔ Media
+
+**Decision**: Use the existing `MediaFile.MediaId` nullable FK as the sole link between a `MediaFile` and a `Media`. Linking = setting `MediaId`; unlinking = nulling it.
+
+**Rationale**: The FK already exists in the domain model. No join table is needed for a many-to-one (file → media) relationship. The `GetMediaByIdQueryHandler` already includes `MediaFiles` via `Include(m => m.MediaFiles)`.
+
+**Alternatives considered**:
+
+- Separate `MediaFileLinkEvent` audit table — over-engineered for a small-team tool; no audit requirement in spec.
+- Many-to-many link table — rejected because a file must belong to at most one media item (FR-004).
+
+**Impact**: Two new MediatR commands (`LinkMediaFileCommand`, `UnlinkMediaFileCommand`). One new admin controller `AdminMediaFilesController`.
+
+---
+
+## R-002 — Root Folder Storage Strategy
+
+**Decision**: Add a nullable `string? RootFolder` column to the `Media` entity/table. Auto-derivation (common parent path of linked files) is computed in the query handler at read time and returned in `MediaDto`. The stored value is only populated when the user explicitly sets/overrides it.
+
+**Rationale**:
+
+- Always recomputing from linked files paths is correct for auto-derivation but may return an incorrect value if files were manually reorganised. Storing the override avoids stale computed values.
+- Keeping auto-derivation as a live computation (not persisted) ensures it always reflects current linked files when no override is set.
+- The API returns the effective root folder = stored override ?? computed auto-derivation.
+
+**Alternatives considered**:
+
+- Always compute, never store — loses manual overrides across page reloads.
+- Always store + recompute on every link/unlink change — premature optimisation; no observed performance issue at this scale.
+
+**Implementation note for `GetMediaByIdQueryHandler`**:
+
+```
+effectiveRootFolder = media.RootFolder   // manual override
+    ?? commonParent(media.MediaFiles.Select(f => f.FilePath))
+    // returns null if no files
+```
+
+Common-parent algorithm: `Path.GetDirectoryName()` of the first file if single file; longest common leading path segments for multiple files.
+
+---
+
+## R-003 — Season Completeness Detection: Data Source
+
+**Decision**: Completeness is derived entirely from the database via the existing `EpisodeFileLink` join table. Episodes with at least one `EpisodeFileLink` record are considered "owned". No live NAS scan is performed on page load.
+
+**Rationale**: The `GetMediaStats` handler already uses `s.TvEpisodes.Any(e => e.EpisodeFileLinks.Any())` to count incomplete TV shows. The same logic can be reused to enumerate missing episodes per season in a new `GetMediaCompletenessQuery`.
+
+**Season 0 exclusion**: Filter `WHERE SeasonNumber > 0 AND NOT (Name ILIKE '%specials%')`.
+
+**Query shape** (`GetMediaCompletenessQueryHandler`):
+
+```csharp
+context.TvSeasons
+    .Include(s => s.TvEpisodes)
+        .ThenInclude(e => e.EpisodeFileLinks)
+    .Where(s => s.MediaId == mediaId && s.SeasonNumber > 0
+                && !s.Name.Contains("specials", StringComparison.OrdinalIgnoreCase))
+    .OrderBy(s => s.SeasonNumber)
+```
+
+**Missing episode list**: For each season, `ownedEpisodeNumbers = episodes.Where(e => e.EpisodeFileLinks.Any()).Select(e => e.EpisodeNumber)`. Missing = all episode numbers in season − owned.
+
+**Alternatives considered**:
+
+- NAS folder scan on demand — requires filesystem access from the API, raises security concerns, contradicts FR-009 ("based on linked files").
+
+---
+
+## R-004 — Unlinked Files List for Link Picker
+
+**Decision**: New `GetUnlinkedFilesQuery` in `Features/Files/Queries/GetUnlinkedFiles/`. Returns paginated `MediaFile` rows where `MediaId IS NULL`, optionally filtered by `MediaType` (Film = single-episode files, TvShow = episode files). Endpoint: `GET /api/v1/admin/media/unlinked-files?page=1&pageSize=20&type=TvShow`.
+
+**Rationale**: The `GetMediaStats` handler already performs `context.MediaFiles.CountAsync(f => f.MediaId == null)`, confirming the pattern is used. Extending it to a paginated list query is straightforward.
+
+**Frontend**: `FileLinkPickerDialogComponent` opens a `p-dialog`, loads unlinked files paginated via the service, and displays file path + size. A "Link" button per row calls `AdminMediaFileLinkService.linkFile()`.
+
+**Filtering by type heuristic**: Pass the current media's type; the handler filters by file path pattern (`/Season` suffix → TvShow) or leaves unfiltered and lets the user search by filename. Given small dataset, no type filter is strictly needed on the backend.
+
+---
+
+## R-005 — Parent-Folder "TMDB Assigned" Label vs InCollection
+
+**Decision**: No backend change required. The API `AdminParentFoldersController` already accepts `status=Assigned` and `status=InCollection` as separate filter values. The frontend `AdminParentFoldersPageComponent` already passes the raw enum value to the API. Only the i18n label for `statusAssigned` needs updating:
+
+- `en.json`: `"statusAssigned": "TMDB Assigned (Pending Import)"`
+- `fr.json`: `"statusAssigned": "TMDB assigné (import en attente)"`
+
+**Rationale**: The existing behaviour is already semantically correct — selecting "Assigned" returns only folders pending import. The confusion stems solely from a vague label. Changing the label is the minimal, zero-risk fix.
+
+**Alternatives considered**:
+
+- Backend: merge Assigned+InCollection under one "TMDB Assigned" status then add a separate "In Collection" → unnecessary churn; the DB already has the right distinction.
+- Rename the enum value in the API — breaking change with no benefit.
+
+---
+
+## R-006 — Admin-Only Guard for Linking Operations
+
+**Decision**: All link/unlink/root-folder/unlinked-files endpoints are placed under the existing `[Authorize(Policy = "AdminOnly")]` policy on a new `AdminMediaFilesController`. The completeness endpoint (`GET /api/v1/media/{id}/completeness`) is on the existing `MediaController` under the standard `[Authorize]` (any authenticated user can read completeness — read-only, no data mutation).
+
+**Rationale**: Consistent with existing API design (`AdminFilesController`, `AdminParentFoldersController` require `AdminOnly`; `MediaController` requires only `Authorize`). The frontend shows the link/unlink/root-folder UI elements only when the current user has the `admin` role (via existing `AuthService.isAdmin` signal).
+
+---
+
+## R-007 — Root Folder Auto-Update on File Link/Unlink
+
+**Decision**: The root folder **is NOT automatically persisted** when files are linked/unlinked. Instead:
+
+- If `Media.RootFolder` is `null` (no override), the API always computes it live from current linked files when returning `MediaDto`.
+- If `Media.RootFolder` is set (manual override), it is returned as-is and is NOT cleared by link/unlink operations.
+- The user can clear the override by sending an empty string to `PATCH /api/v1/admin/media/{id}/root-folder`.
+
+**This resolves the spec contradiction** (US2 acceptance scenario 4 says "missing episode detection runs against the new path" — this refers to the completeness panel re-loading after a root folder edit triggers a page refresh, not a folder scan; the panel is always based on linked files, not the folder path).
+
+**Rationale**: Avoids unexpected side-effects where linking a new file silently overwrites a carefully set root folder.

--- a/specs/007-media-file-linking/spec.md
+++ b/specs/007-media-file-linking/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Media File Linking & Missing Content Detection
+
+**Feature Branch**: `feature/007-media-file-linking`
+**Created**: 2026-05-21
+**Status**: Draft
+**Input**: User description: "Link media files to each TV show or film from detail pages. Link the root folder and open file explorer. Detect missing episodes & seasons (ignore season 0). Scan result page filter: 'TMDB Assigned' should only show entries with a TMDB match but not yet imported into the collection."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — Media File Linking from Detail Page (Priority: P1)
+
+A user views the detail page of a TV show or film in their collection. Alongside the existing file list, they see any media files that are currently linked to this media item plus a control to link additional unlinked files found on the NAS. The user selects one or more unlinked files (e.g., episodes discovered during a scan that were not automatically matched) and clicks "Link file(s)". The selected files are immediately associated with the media item and appear in the file list. The user can also unlink an existing file from the media item if it was incorrectly assigned.
+
+**Why this priority**: The current workflow forces admins to link files solely from the admin scan results page, which breaks the natural flow of browsing the collection. Being able to link/unlink files from the media detail page reduces context-switching and makes corrections faster.
+
+**Independent Test**: Navigate to any TV show or film detail page. Confirm the file list shows linked files with an unlink action. Confirm a "Link file" control is present. Select an unlinked file, link it, and verify it appears in the file list. Unlink a file and verify it disappears from the list.
+
+**Acceptance Scenarios**:
+
+1. **Given** a media detail page for a TV show with linked files, **When** the page loads, **Then** all currently linked media files are listed with their file paths and an "Unlink" action button for each.
+2. **Given** a media detail page, **When** the user opens the "Link file" control, **Then** a searchable list of unlinked files (files with no associated media) is presented, filtered to files plausibly belonging to this media (same genre/type).
+3. **Given** the user selects one or more unlinked files and confirms the link action, **When** the operation completes, **Then** the selected files appear in the linked file list without requiring a page reload.
+4. **Given** the user clicks "Unlink" on a linked file, **When** the confirmation is accepted, **Then** the file is removed from the media item's file list and returned to the unlinked pool.
+5. **Given** a film detail page (as opposed to a TV show), **When** the user links a file, **Then** the same linking behavior applies regardless of media type.
+6. **Given** no unlinked files exist, **When** the user opens the "Link file" control, **Then** a message indicates that no unlinked files are available.
+
+---
+
+### User Story 2 — Root Folder Association & File Explorer Access (Priority: P1)
+
+A user views a TV show or film in their collection. The detail page displays a "Root Folder" field showing the primary directory on the NAS where this media's files reside. For TV shows, this is the folder containing all season sub-folders. For films, this is the folder containing the film file. The user can click an "Open in explorer" action which copies the folder path to the clipboard (or launches a system file-manager protocol link) so they can navigate to it immediately. The user can also manually update the root folder if the detected path is incorrect.
+
+**Why this priority**: Direct access to the physical location of media is a core utility for power users managing a NAS library. It bridges the gap between the web interface and the local file system, enabling quick manual operations without leaving the app.
+
+**Independent Test**: View a film and a TV show detail page. Confirm the root folder path is displayed for each. Click "Open in explorer", confirm the path is copied to the clipboard. Update the root folder to a different path and confirm the change persists.
+
+**Acceptance Scenarios**:
+
+1. **Given** a media item with at least one linked file, **When** the user views the detail page, **Then** the root folder path is displayed — derived automatically from the common parent directory of the linked files.
+2. **Given** the user clicks the "Open in explorer" button, **When** clipboard access is available, **Then** the root folder path is copied to the clipboard and a confirmation toast is shown.
+3. **Given** clipboard access is blocked by the browser, **When** the user clicks "Open in explorer", **Then** a fallback dialog displays the path in a selectable text field for manual copying.
+4. **Given** the user edits the root folder path manually and saves, **When** the update completes, **Then** the new path is stored and displayed, and missing episode detection runs against the new path.
+5. **Given** a media item with no linked files, **When** the user views the detail page, **Then** the root folder field shows an empty state with a prompt to link files or set the path manually.
+6. **Given** a TV show with files spread across multiple directories, **When** the root folder is displayed, **Then** it shows the highest common parent directory among all linked files.
+
+---
+
+### User Story 3 — Missing Episodes & Seasons Detection (Priority: P1)
+
+A user views a TV show in their collection. A "Completeness" section on the detail page lists each season expected by TMDB. For each season (excluding season 0 and specials), the user sees how many episodes they own versus the total expected, and which specific episode numbers are missing. A visual indicator (e.g., a progress bar or badge) gives a quick glance at overall completeness. The missing episodes are derived from the linked files on record — no live NAS scan is triggered on page load.
+
+**Why this priority**: Identifying missing content is one of the core reasons users maintain a media library application. Without this, users must manually cross-reference their files against TMDB data, which is the main pain point this feature resolves.
+
+**Independent Test**: View a TV show that has 3 seasons on TMDB but only 2 seasons of files linked. Confirm seasons 1 and 2 show their owned episodes. Confirm season 3 appears as fully missing. Verify season 0 is not shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** a TV show detail page, **When** the completeness section loads, **Then** each numbered season (season 1, 2, 3… — excluding season 0 and specials) is listed with the count of owned episodes vs. total TMDB episodes.
+2. **Given** a season where the user owns all episodes, **When** the completeness section renders, **Then** that season is marked as complete with a visual "complete" indicator.
+3. **Given** a season where some episodes are missing, **When** the completeness section renders, **Then** the specific missing episode numbers are listed or indicated (e.g., "Missing: E03, E05, E07").
+4. **Given** a season that is entirely absent from the user's linked files, **When** the completeness section renders, **Then** the entire season is shown as missing with an "0 / N episodes" count.
+5. **Given** a TV show that has season 0 (specials) defined on TMDB, **When** the completeness section renders, **Then** season 0 and specials seasons are not shown — only numbered seasons starting from season 1.
+6. **Given** a TV show where all seasons and episodes are present, **When** the completeness section renders, **Then** an "All seasons complete" summary is displayed with no missing indicators.
+7. **Given** a film (not a TV show), **When** the user views the detail page, **Then** no completeness section is shown — this feature applies to TV shows only.
+
+---
+
+### User Story 4 — Scan Results Filter: "TMDB Assigned (Pending Import)" (Priority: P2)
+
+An admin user is on the scan results page (parent folders view). The current filter options are "Non assigned" and "TMDB assigned". The admin selects the "TMDB assigned" filter and expects to see only the folders/groups that have a TMDB match recorded from the scan (i.e., a TMDB entry was identified during scanning or manually assigned) but whose media has **not yet been imported** into the collection. Folders already fully imported into the collection with enriched metadata are excluded from this view, making it clearly actionable: everything in the "TMDB Assigned" filter still requires the import/enrichment step to be completed.
+
+**Why this priority**: The current "TMDB assigned" label is ambiguous — it could mean "has assignment in scan DB" (pending import) or "already in collection". Clarifying this makes the admin's workflow unambiguous: the "TMDB assigned" list is exactly the backlog of pending imports, and the admin knows each item in this list still needs action.
+
+**Independent Test**: Set up three folders: one unassigned, one assigned-but-not-imported, one fully in-collection. Select "TMDB Assigned" filter. Confirm only the assigned-but-not-imported folder appears. Confirm neither the unassigned nor the in-collection folder appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** the scan results page, **When** the user applies the "TMDB Assigned" filter, **Then** only folders/groups with a TMDB match recorded but not yet imported into the collection are shown.
+2. **Given** a folder that is fully imported and enriched in the media collection (status: InCollection), **When** the "TMDB Assigned" filter is active, **Then** this folder does NOT appear in the filtered results.
+3. **Given** a folder with no TMDB assignment (status: NotAssigned), **When** the "TMDB Assigned" filter is active, **Then** this folder does NOT appear in the filtered results.
+4. **Given** the "Non Assigned" filter is selected, **When** applied, **Then** only folders with no TMDB match at all are shown — behavior unchanged from current.
+5. **Given** an admin wants to view items already in the collection, **When** they select the "In Collection" filter (new option), **Then** only folders whose media is fully imported and enriched in the collection are shown.
+6. **Given** all filters are cleared (no filter active), **When** the page loads, **Then** all folders regardless of status are shown.
+
+---
+
+### Edge Cases
+
+- What happens when a file is linked to a media item but is physically missing from the NAS? The file is displayed with a "file not found" indicator, but the link record remains in the database until explicitly removed.
+- What happens when the user tries to link the same file to two different media items? The system rejects the second link with an error message indicating the file is already linked to another media item.
+- What happens when the root folder cannot be auto-detected (no linked files)? The root folder field shows an empty state and the user can set it manually.
+- What happens when TMDB episode count data is unavailable (no enrichment yet)? The completeness section shows a message indicating enrichment is needed before missing episode detection can run.
+- What happens when a TV show has no enriched season data (NumberOfSeasons is null)? The completeness section shows a "Metadata not available" message rather than an empty list.
+- What happens when a file unlink operation leaves the media item with zero linked files? The root folder is cleared automatically unless the user has manually set a custom root folder path.
+- What happens when the "TMDB Assigned" filter is applied but there are no pending-import entries? An empty state message is shown ("All TMDB-matched entries have been imported into the collection").
+- What happens when there are hundreds of unlinked files and the user opens the "Link file" control? The list is paginated or filtered by media type/name to avoid overwhelming the user.
+- What happens when a TV show's linked files span mixed episode naming (e.g., some files match standard naming, others do not)? The episode matching logic uses the episode number extracted from the file path and falls back to sequential order if the pattern is ambiguous.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST display all currently linked media files on the detail page for any TV show or film, with individual unlink actions for each file.
+- **FR-002**: System MUST provide a "Link file" control on media detail pages that presents a list of unlinked media files for the user to select and associate.
+- **FR-003**: System MUST immediately reflect newly linked or unlinked files in the detail page file list without requiring a full page reload.
+- **FR-004**: System MUST prevent the same media file from being linked to more than one media item simultaneously, returning a clear error if attempted.
+- **FR-005**: System MUST display the root folder path on each media detail page, auto-derived from the common parent directory of linked files when not explicitly set.
+- **FR-006**: System MUST provide an "Open in explorer" action on the detail page that copies the root folder path to the clipboard.
+- **FR-007**: System MUST provide a fallback text display of the root folder path when clipboard access is denied by the browser.
+- **FR-008**: System MUST allow the user to manually override the root folder path on a media detail page, with the change persisted on the media record.
+- **FR-009**: System MUST display a completeness section on TV show detail pages listing each season (season 1 and above) with owned vs. total episode counts.
+- **FR-010**: System MUST exclude season 0 and any season explicitly typed as "Specials" from the completeness section.
+- **FR-011**: System MUST identify and display the specific missing episode numbers within each incomplete season.
+- **FR-012**: System MUST show a "complete" indicator for seasons where all TMDB-expected episodes are present in the linked files.
+- **FR-013**: System MUST not show a completeness section on film detail pages.
+- **FR-014**: System MUST show a "Metadata not available" message in the completeness section when the TV show has not yet been enriched with TMDB season/episode data.
+- **FR-015**: System MUST update the "TMDB Assigned" filter on the scan results page to display only folders/groups with a TMDB match that have NOT yet been imported into the media collection (status: Assigned, not InCollection).
+- **FR-016**: System MUST NOT include folders with "InCollection" status in the "TMDB Assigned" filter results.
+- **FR-017**: System MUST add an "In Collection" filter option to the scan results page to display folders whose media is already fully imported and enriched in the collection.
+- **FR-018**: System MUST preserve existing "Non Assigned" filter behavior — showing only folders with no TMDB match.
+- **FR-019**: System MUST support showing all folders regardless of status when no filter is applied on the scan results page.
+
+### Key Entities _(include if feature involves data)_
+
+- **Media File Link**: Represents the association between a `MediaFile` (physical file on NAS) and a `Media` entity (TV show or film in the collection). A file may be linked to at most one media item. Attributes: file ID, media ID, file path, link status.
+- **Root Folder**: The primary directory path on the NAS associated with a media item. Can be auto-derived from linked files' common parent, or manually set by the user. Stored on the `Media` entity. Attributes: absolute path, derivation source (auto/manual).
+- **Season Completeness**: Derived data for a TV show comparing owned episode numbers (from linked files) against TMDB expected episodes per season. Excludes season 0 and special seasons. Attributes: season number, total expected episodes (TMDB), owned episode numbers, missing episode numbers, is complete flag.
+- **Parent Folder Assignment Status (refined)**: The status of a scan result folder entry. Values: `NotAssigned` (no TMDB match), `Assigned` (TMDB match recorded but not yet imported into collection), `InCollection` (fully imported and enriched media record exists). The "TMDB Assigned" filter maps exclusively to the `Assigned` status.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A user can link an unlinked file to a media item from the detail page in under 30 seconds, with no navigation to the admin scan results page required.
+- **SC-002**: 100% of media detail pages for items with linked files display the root folder path correctly derived from those files' common parent directory.
+- **SC-003**: The "Open in explorer" action successfully delivers the root folder path (via clipboard or fallback display) on 100% of invocations in supported browsers.
+- **SC-004**: The completeness section correctly identifies all missing seasons and episodes for 100% of enriched TV shows tested, with season 0 excluded in all cases.
+- **SC-005**: The completeness section loads within 2 seconds of the TV show detail page opening, without requiring a separate user action.
+- **SC-006**: After applying the "TMDB Assigned" filter on the scan results page, 0% of results belong to the "InCollection" status — every visible entry is a pending import item.
+- **SC-007**: The "In Collection" filter on the scan results page correctly shows only fully imported entries, with 0 false positives or false negatives.
+- **SC-008**: Linking or unlinking a file from the detail page reflects in the file list within 1 second of the action completing.
+
+## Assumptions
+
+- The `MediaFile` entity already has a `FilePath` attribute (string) and a nullable `MediaId` foreign key; no schema changes are needed for the link/unlink feature beyond ensuring the relationship is updatable via a new API endpoint.
+- The `Media` entity does not currently have a `RootFolder` field; a new nullable `string RootFolder` column will be added to store the manually-set or auto-derived path.
+- Auto-derivation of root folder uses the common parent directory of all linked `MediaFile.FilePath` values for a given media item. For a single file, the parent directory of that file is used.
+- Episode number matching (for completeness detection) relies on the episode numbers already parsed and stored in `TvEpisode` records linked to the media files, rather than re-parsing file names on the fly.
+- TMDB season/episode metadata is already enriched and available via the existing `TvSeason` / `TvEpisode` entities populated during the enrichment pipeline; no additional TMDB API calls are needed for completeness detection.
+- Season 0 exclusion is implemented by filtering out any `TvSeason` where `SeasonNumber == 0` or `Name` contains "Specials" (case-insensitive).
+- The scan results page already uses `ParentFolderGroupDto` with statuses `NotAssigned`, `Assigned`, and `InCollection`; the "TMDB Assigned" filter will be remapped to query only `Assigned` status from the backend.
+- A new "In Collection" filter option on the scan results page will query the `InCollection` status.
+- The `ListParentFoldersQuery` already accepts a `status` string parameter; the change is purely in how the frontend labels and maps the filter values, plus ensuring the API correctly distinguishes `Assigned` from `InCollection`.
+- Linking a file from the detail page calls a new `PUT /api/v1/media/{mediaId}/files/{fileId}/link` endpoint (or equivalent) and unlinking calls a corresponding `DELETE` or `PUT` endpoint. These endpoints handle updating `MediaFile.MediaId` and related `ScanItemDecision` records.
+- The "Link file" control on the detail page fetches unlinked files from an existing or new `GET /api/v1/admin/files?unlinked=true&type={mediaType}` endpoint, paginated.
+- File-explorer "opening" is client-side only — the app copies the path to the clipboard; no server-side process is launched. A system file-manager URI scheme (e.g., `file://`) may be used as a progressive enhancement where supported.

--- a/specs/007-media-file-linking/tasks.md
+++ b/specs/007-media-file-linking/tasks.md
@@ -1,0 +1,245 @@
+# Tasks: Media File Linking & Missing Content Detection
+
+**Input**: Design documents from `specs/007-media-file-linking/`  
+**Prerequisites**: plan.md ✅ spec.md ✅ research.md ✅ data-model.md ✅ contracts/api-contracts.md ✅ quickstart.md ✅
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+- Tests are included per the project constitution (≥80% statement coverage mandatory)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the new domain column and shared types that all user stories depend on.
+
+- [ ] T001 Add `RootFolder string?` property to `MediaHandler.Domain/Entities/Media.cs`
+- [ ] T002 Map `root_folder` column in `MediaHandler.Infrastructure/Persistence/Configurations/MediaConfiguration.cs`
+- [ ] T003 Generate and apply EF Core migration `AddMediaRootFolder` in `MediaHandler.Infrastructure/Persistence/Migrations/`
+- [ ] T004 [P] Add `RootFolder string?` field to `MediaHandler.Application/Features/Media/DTOs/MediaDto.cs` record
+- [ ] T005 [P] Add `SeasonCompletenessDto` record to `MediaHandler.Application/Features/Media/DTOs/SeasonCompletenessDto.cs`
+- [ ] T006 [P] Add `UnlinkedFileDto` record to `MediaHandler.Application/Features/Files/Queries/GetUnlinkedFiles/UnlinkedFileDto.cs`
+- [x] T007 [P] Update `src/app/shared/models/media.model.ts` — add `rootFolder: string | null` to `Media` interface and add `SeasonCompleteness` + `UnlinkedFile` interfaces
+- [x] T008 [P] Create `AdminMediaFileLinkService` skeleton (signals + method stubs) in `src/app/core/services/admin-media-file-link.service.ts`
+
+**Checkpoint**: Domain column exists in DB; all DTOs and frontend interfaces defined; service skeleton ready.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Backend handlers and controller structure that all user-story phases depend on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T009 Create `AdminMediaFilesController.cs` skeleton with `[ApiController]`, `[Route("api/v1/admin/media")]`, `[Authorize(Policy = "AdminOnly")]` and `[EnableRateLimiting("fixed")]` in `MediaHandler.API/Controllers/AdminMediaFilesController.cs`
+- [ ] T010 [P] Update `MediaHandler.Application/Features/Media/Queries/GetMediaById/GetMediaByIdQueryHandler.cs` to compute `effectiveRootFolder` (stored override ?? common parent of linked file paths) and populate `MediaDto.RootFolder`
+
+**Checkpoint**: Foundation ready; all user story phases can start.
+
+---
+
+## Phase 3: User Story 1 — Media File Linking from Detail Page (Priority: P1) 🎯 MVP
+
+**Goal**: Admin can link unlinked `MediaFile` records to a `Media` item from its detail page and unlink existing files.
+
+**Independent Test**: Navigate to a TV show detail page as admin. Confirm "Unlink" button visible per file. Open link picker dialog, select an unlinked file, link it, verify it appears in the list. Unlink it, verify it disappears. As non-admin user, verify no link/unlink controls appear.
+
+### Backend — US1
+
+- [ ] T011 [P] [US1] Create `GetUnlinkedFilesQueryHandler.cs` that returns paginated `MediaFile` where `MediaId IS NULL` in `MediaHandler.Application/Features/Files/Queries/GetUnlinkedFiles/GetUnlinkedFilesQueryHandler.cs`
+- [ ] T012 [P] [US1] Create `LinkMediaFileCommandHandler.cs` — set `MediaFile.MediaId = mediaId`; return `FILE_ALREADY_LINKED` 422 if file is already linked to another media in `MediaHandler.Application/Features/Media/Commands/LinkMediaFile/LinkMediaFileCommandHandler.cs`
+- [ ] T013 [P] [US1] Create `UnlinkMediaFileCommandHandler.cs` — set `MediaFile.MediaId = null`; return 404 if file not found or not linked to this media in `MediaHandler.Application/Features/Media/Commands/UnlinkMediaFile/UnlinkMediaFileCommandHandler.cs`
+- [ ] T014 [US1] Add three endpoints to `AdminMediaFilesController.cs`: `GET /admin/media/unlinked-files` (paginated), `PUT /admin/media/{mediaId}/files/{fileId}/link`, `DELETE /admin/media/{mediaId}/files/{fileId}/link` per `contracts/api-contracts.md`
+
+### Frontend — US1
+
+- [x] T015 [US1] Implement `getUnlinkedFiles(page, pageSize)`, `linkFile(mediaId, fileId)`, `unlinkFile(mediaId, fileId)` in `src/app/core/services/admin-media-file-link.service.ts`
+- [x] T016 [P] [US1] Create `FileLinkPickerDialogComponent` with `p-dialog` + paginated `p-table` of unlinked files, "Link" button per row, `visible` input signal in `src/app/features/media-detail/file-link-picker-dialog.component.ts` + `.html` + `.scss`
+- [x] T017 [US1] Update `MediaDetailService` — add `linkFile(mediaId, fileId)` and `unlinkFile(mediaId, fileId)` methods that call `AdminMediaFileLinkService` then refresh `loadMedia()` in `src/app/features/media-detail/media-detail.service.ts`
+- [x] T018 [US1] Update `MediaFilesComponent` — add "Unlink" button per file (visible only when `isAdmin` signal is true) and "Link File" button that emits event to open picker dialog in `src/app/features/media-detail/media-files.component.ts` + `.html`
+- [x] T019 [US1] Update `MediaDetailPageComponent` — inject `AuthService`, add `isAdmin` computed signal, add `FileLinkPickerDialogComponent`, wire open/close link picker dialog and link/unlink actions in `src/app/features/media-detail/media-detail-page.component.ts`
+
+### Tests — US1
+
+- [x] T020 [P] [US1] Write unit tests for `AdminMediaFileLinkService.linkFile()`, `unlinkFile()`, `getUnlinkedFiles()` in `src/app/core/services/admin-media-file-link.service.spec.ts`
+- [x] T021 [P] [US1] Write unit tests for `FileLinkPickerDialogComponent` — renders file list, emits link event on button click, shows empty state in `src/app/features/media-detail/file-link-picker-dialog.component.spec.ts`
+- [ ] T022 [P] [US1] Write xUnit tests for `GetUnlinkedFilesQueryHandler`, `LinkMediaFileCommandHandler`, `UnlinkMediaFileCommandHandler` in `MediaHandler.Tests/Features/Media/FileLinkCommandHandlerTests.cs`
+
+**Checkpoint**: US1 fully functional and testable — admin can link/unlink files from the detail page.
+
+---
+
+## Phase 4: User Story 2 — Root Folder Association & File Explorer Access (Priority: P1)
+
+**Goal**: Each media detail page shows the root folder path (auto-derived or manually set) with a copy-to-clipboard action and an inline edit for admin users.
+
+**Independent Test**: View a film and a TV show as admin. Confirm root folder auto-derived from linked files' common parent. Click "Open in explorer" → path copied to clipboard (toast shown). Block clipboard → fallback text field appears. Edit root folder, save, reload → persists. Clear override → auto-derived path returns.
+
+### Backend — US2
+
+- [ ] T023 [US2] Create `UpdateMediaRootFolderCommandHandler.cs` — sets/clears `Media.RootFolder`; saves via EF Core in `MediaHandler.Application/Features/Media/Commands/UpdateMediaRootFolder/UpdateMediaRootFolderCommandHandler.cs`
+- [ ] T024 [US2] Add `PATCH /admin/media/{mediaId}/root-folder` endpoint to `AdminMediaFilesController.cs` per `contracts/api-contracts.md`
+
+### Frontend — US2
+
+- [x] T025 [US2] Implement `updateRootFolder(mediaId, rootFolder)` in `src/app/core/services/admin-media-file-link.service.ts`
+- [x] T026 [P] [US2] Create `RootFolderComponent` — displays effective root folder, "Open in explorer" clipboard button with `ClipboardService` fallback textarea, inline edit input + save button (admin-only) in `src/app/features/media-detail/root-folder.component.ts` + `.html` + `.scss`
+- [x] T027 [US2] Update `MediaDetailService` — add `updateRootFolder(mediaId, path)` method that calls `AdminMediaFileLinkService.updateRootFolder()` then refreshes `loadMedia()` in `src/app/features/media-detail/media-detail.service.ts`
+- [x] T028 [US2] Update `MediaDetailPageComponent` — add `<app-root-folder>` after the media header, pass `media()?.rootFolder` and `mediaId()`, wire save action in `src/app/features/media-detail/media-detail-page.component.ts`
+
+### Tests — US2
+
+- [x] T029 [P] [US2] Write unit tests for `RootFolderComponent` — displays path, emits copy action, shows edit input for admin, shows empty state when null in `src/app/features/media-detail/root-folder.component.spec.ts`
+- [ ] T030 [P] [US2] Write xUnit tests for `UpdateMediaRootFolderCommandHandler` — sets path, clears path (null input), returns 404 for unknown media in `MediaHandler.Tests/Features/Media/UpdateMediaRootFolderCommandHandlerTests.cs`
+
+**Checkpoint**: US2 fully functional — root folder displayed and editable in detail page.
+
+---
+
+## Phase 5: User Story 3 — Missing Episodes & Seasons Detection (Priority: P1)
+
+**Goal**: TV show detail pages display a "Completeness" section listing owned vs. expected episodes per season (season 1+), with specific missing episode numbers listed.
+
+**Independent Test**: View a TV show with 3 seasons on TMDB, only 2 seasons of files linked. Confirm season 0 absent. Confirm seasons 1–2 show owned count. Confirm season 3 shows "0 / N episodes". Confirm a fully owned season shows ✅ complete badge. View a film — no completeness section present.
+
+### Backend — US3
+
+- [ ] T031 [US3] Create `GetMediaCompletenessQueryHandler.cs` — queries `TvSeasons` + `TvEpisodes` + `EpisodeFileLinks` for the given `mediaId`, excludes `SeasonNumber == 0` and seasons named "Specials", returns `IReadOnlyList<SeasonCompletenessDto>` per `data-model.md` derivation logic in `MediaHandler.Application/Features/Media/Queries/GetMediaCompleteness/GetMediaCompletenessQueryHandler.cs`
+- [ ] T032 [US3] Add `GET /media/{id}/completeness` endpoint to `MediaController.cs` — returns 400 for Film type, 200 with completeness list for TvShow, empty array if no TvSeason data in `MediaHandler.API/Controllers/MediaController.cs`
+
+### Frontend — US3
+
+- [x] T033 [P] [US3] Create `SeasonCompletenessComponent` — displays completeness list for TV shows, season rows with owned/total counts, missing episode numbers, complete badge, "Metadata not available" empty state in `src/app/features/media-detail/season-completeness.component.ts` + `.html` + `.scss`
+- [x] T034 [US3] Update `MediaDetailService` — add `completeness = signal<SeasonCompleteness[]>([])`, `completenessLoading`, `completenessError` signals and `loadCompleteness(mediaId)` method (called from `loadMedia()` when type is TvShow) in `src/app/features/media-detail/media-detail.service.ts`
+- [x] T035 [US3] Update `MediaDetailPageComponent` — add `<app-season-completeness>` below the season list (TV shows only), pass `completeness()` and `completenessLoading()` signals in `src/app/features/media-detail/media-detail-page.component.ts`
+
+### Tests — US3
+
+- [ ] T036 [P] [US3] Write xUnit tests for `GetMediaCompletenessQueryHandler` — season 0 excluded, specials excluded, missing episodes correctly computed, empty list when no TvSeasons, 400 for Film in `MediaHandler.Tests/Features/Media/GetMediaCompletenessQueryHandlerTests.cs`
+- [x] T037 [P] [US3] Write unit tests for `SeasonCompletenessComponent` — renders seasons, shows complete badge, lists missing episode numbers, shows empty state, hidden for films in `src/app/features/media-detail/season-completeness.component.spec.ts`
+
+**Checkpoint**: US3 fully functional — completeness panel visible on all enriched TV show detail pages.
+
+---
+
+## Phase 6: User Story 4 — Parent-Folder Filter Label Clarification (Priority: P2)
+
+**Goal**: The "Assigned" filter label on the parent folders page is renamed to "TMDB Assigned (Pending Import)" to unambiguously signal that selected entries are awaiting collection import.
+
+**Independent Test**: Navigate to Admin → Parent Folders. Open the status filter dropdown. Confirm "TMDB Assigned (Pending Import)" appears (EN) and "TMDB assigné (import en attente)" (FR). Select it — only folders with `status=Assigned` (not `InCollection`) are shown.
+
+- [x] T038 [P] [US4] Update `src/assets/i18n/en.json` — change `admin.parentFolders.statusAssigned` from `"Assigned"` to `"TMDB Assigned (Pending Import)"`
+- [x] T039 [P] [US4] Update `src/assets/i18n/fr.json` — change `admin.parentFolders.statusAssigned` from `"Assigné"` to `"TMDB assigné (import en attente)"`
+
+**Checkpoint**: US4 complete — filter label clarified, no backend or logic change needed.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: i18n completeness, bundle validation, and end-to-end quickstart verification.
+
+- [x] T040 [P] Add all new `mediaDetail.*` i18n keys (file linking section, root folder section, completeness section labels) to `src/assets/i18n/en.json`
+- [x] T041 [P] Add all new `mediaDetail.*` i18n keys (French translations) to `src/assets/i18n/fr.json`
+- [x] T042 [P] Run `ng build --configuration production` and confirm bundle sizes stay within `angular.json` budget limits (initial ≤500 kB warning / 1 MB error)
+- [ ] T043 Run the full quickstart.md verification checklist for all 4 user stories — confirm all checkboxes pass
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately. T001–T003 must complete sequentially (domain → config → migration). T004–T008 can run in parallel after T001.
+- **Phase 2 (Foundational)**: Depends on Phase 1. T009–T010 can run in parallel after Phase 1.
+- **Phase 3 (US1)**: Depends on Phase 2 completion. Backend tasks T011–T014 and frontend tasks T015–T019 can largely run in parallel across back/front.
+- **Phase 4 (US2)**: Depends on Phase 2 (and T009 for controller). T023–T024 depend on T009.
+- **Phase 5 (US3)**: Depends on Phase 2. Independent from US1 and US2.
+- **Phase 6 (US4)**: Fully independent — can start any time after Phase 1.
+- **Phase 7 (Polish)**: Depends on all desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: After Phase 2 — no dependency on US2, US3, US4.
+- **US2 (P1)**: After Phase 2 — depends on T009 (controller skeleton). Can run in parallel with US1.
+- **US3 (P1)**: After Phase 2 — fully independent of US1 and US2.
+- **US4 (P2)**: After Phase 1 — fully independent, only i18n files touched.
+
+### Within Each User Story
+
+- Backend commands/queries (marked [P]) → controller endpoint → frontend service → component → page integration
+- Tests can be written in parallel with implementation (same user story, different files)
+
+---
+
+## Parallel Example: US1 Backend
+
+```
+Parallel (different files, no dependencies on each other):
+  T011 — GetUnlinkedFilesQueryHandler.cs
+  T012 — LinkMediaFileCommandHandler.cs
+  T013 — UnlinkMediaFileCommandHandler.cs
+
+Then (depends on all three):
+  T014 — AdminMediaFilesController.cs endpoints
+```
+
+## Parallel Example: US3
+
+```
+Parallel (backend + frontend simultaneously):
+  T031 — GetMediaCompletenessQueryHandler.cs
+  T033 — SeasonCompletenessComponent (frontend)
+
+Then sequentially:
+  T032 — MediaController completeness endpoint  (depends on T031)
+  T034 — MediaDetailService.loadCompleteness()  (depends on T033 interface)
+  T035 — MediaDetailPageComponent integration   (depends on T033, T034)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only — File Linking)
+
+1. Complete Phase 1 (Setup)
+2. Complete Phase 2 (Foundational)
+3. Complete Phase 3 (US1)
+4. **STOP and VALIDATE**: Admin can link/unlink files from detail page
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Phase 1 + 2 → Foundation ready
+2. Phase 3 (US1) → File linking from detail page ✅
+3. Phase 4 (US2) → Root folder display + clipboard ✅
+4. Phase 5 (US3) → Season completeness panel ✅
+5. Phase 6 (US4) → Filter label clarification ✅ (can be done any time)
+6. Phase 7 → Polish + validation ✅
+
+### Parallel Team Strategy
+
+With two developers after Phase 2 completes:
+
+- **Dev A**: US1 (T011→T022) — file linking
+- **Dev B**: US3 (T031→T037) — completeness (fully independent)
+- **Dev A or B**: US2 (T023→T030) after US1 backend controller exists
+- US4 (T038–T039) can be done by either dev at any point
+
+---
+
+## Notes
+
+- All new Angular components: `ChangeDetectionStrategy.OnPush` mandatory (constitution)
+- All new Angular components: standalone, no NgModules (constitution)
+- State management: `signal()` only; no `BehaviorSubject` (constitution)
+- Streams: `toSignal()` or `takeUntilDestroyed(destroyRef)` — no manual `unsubscribe()` (constitution)
+- No new third-party npm packages — PrimeNG dialog/table already bundled
+- EF migration (T003) must be applied before any backend endpoint test
+- Backend xUnit tests (T022, T030, T036) are companion changes in `MediaHandler.API` repo

--- a/src/app/core/api/api-response.model.ts
+++ b/src/app/core/api/api-response.model.ts
@@ -18,11 +18,11 @@ export interface ApiResponse<T> {
 
 export interface CollectionStats {
   totalMedia: number;
-  totalFilms: number;
-  totalTvShows: number;
-  totalWatched: number;
-  totalUnwatched: number;
+  films: number;
+  tvShows: number;
+  watchedByCurrentUser: number;
+  unwatchedByCurrentUser: number;
   totalFiles: number;
-  totalUnlinkedFiles: number;
+  unlinkedFiles: number;
   incompleteTvShowCount: number;
 }

--- a/src/app/core/api/api.service.ts
+++ b/src/app/core/api/api.service.ts
@@ -56,6 +56,22 @@ export class ApiService {
     return this.http.put<ApiResponse<T>>(`${this.baseUrl}/${path}`, body, { params: httpParams });
   }
 
+  patch<T>(
+    path: string,
+    body: unknown,
+    params?: Record<string, string | number | boolean | null | undefined>,
+  ): Observable<ApiResponse<T>> {
+    let httpParams = new HttpParams();
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== null && value !== undefined) {
+          httpParams = httpParams.set(key, String(value));
+        }
+      }
+    }
+    return this.http.patch<ApiResponse<T>>(`${this.baseUrl}/${path}`, body, { params: httpParams });
+  }
+
   delete<T>(path: string): Observable<ApiResponse<T>> {
     return this.http.delete<ApiResponse<T>>(`${this.baseUrl}/${path}`);
   }

--- a/src/app/core/services/admin-media-file-link.service.spec.ts
+++ b/src/app/core/services/admin-media-file-link.service.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { AdminMediaFileLinkService } from './admin-media-file-link.service';
+import { environment } from '@env/environment';
+
+describe('AdminMediaFileLinkService', () => {
+  let service: AdminMediaFileLinkService;
+  let httpMock: HttpTestingController;
+
+  const base = environment.apiBaseUrl;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AdminMediaFileLinkService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(AdminMediaFileLinkService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('creates the service', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getUnlinkedFiles', () => {
+    it('calls GET /admin/media/unlinked-files with default page params', () => {
+      service.getUnlinkedFiles().subscribe();
+      const req = httpMock.expectOne(
+        (r) =>
+          r.url === `${base}/admin/media/unlinked-files` &&
+          r.params.get('page') === '1' &&
+          r.params.get('pageSize') === '20',
+      );
+      expect(req.request.method).toBe('GET');
+      req.flush({ data: [], meta: { page: 1, pageSize: 20, totalCount: 0, totalPages: 0 } });
+    });
+
+    it('calls GET /admin/media/unlinked-files with custom page params', () => {
+      service.getUnlinkedFiles(2, 50).subscribe();
+      const req = httpMock.expectOne(
+        (r) =>
+          r.url === `${base}/admin/media/unlinked-files` &&
+          r.params.get('page') === '2' &&
+          r.params.get('pageSize') === '50',
+      );
+      expect(req.request.method).toBe('GET');
+      req.flush({ data: [], meta: { page: 2, pageSize: 50, totalCount: 0, totalPages: 0 } });
+    });
+  });
+
+  describe('linkFile', () => {
+    it('calls PUT /admin/media/{mediaId}/files/{fileId}/link', () => {
+      service.linkFile('media-1', 'file-1').subscribe();
+      const req = httpMock.expectOne(`${base}/admin/media/media-1/files/file-1/link`);
+      expect(req.request.method).toBe('PUT');
+      req.flush({ data: null });
+    });
+  });
+
+  describe('unlinkFile', () => {
+    it('calls DELETE /admin/media/{mediaId}/files/{fileId}/link', () => {
+      service.unlinkFile('media-1', 'file-1').subscribe();
+      const req = httpMock.expectOne(`${base}/admin/media/media-1/files/file-1/link`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush({ data: null });
+    });
+  });
+
+  describe('updateRootFolder', () => {
+    it('calls PATCH /admin/media/{mediaId}/root-folder with path', () => {
+      service.updateRootFolder('media-1', '/nas/tv').subscribe();
+      const req = httpMock.expectOne(`${base}/admin/media/media-1/root-folder`);
+      expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual({ rootFolder: '/nas/tv' });
+      req.flush({ data: null });
+    });
+
+    it('calls PATCH /admin/media/{mediaId}/root-folder with null to clear', () => {
+      service.updateRootFolder('media-1', null).subscribe();
+      const req = httpMock.expectOne(`${base}/admin/media/media-1/root-folder`);
+      expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual({ rootFolder: null });
+      req.flush({ data: null });
+    });
+  });
+});

--- a/src/app/core/services/admin-media-file-link.service.ts
+++ b/src/app/core/services/admin-media-file-link.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from '@core/api/api.service';
+import { ApiResponse } from '@core/api/api-response.model';
+import { UnlinkedFile } from '@shared/models/media.model';
+
+@Injectable({ providedIn: 'root' })
+export class AdminMediaFileLinkService {
+  private readonly api = inject(ApiService);
+
+  /**
+   * T015: GET /api/v1/admin/media/unlinked-files — paginated list of unlinked MediaFile rows.
+   */
+  getUnlinkedFiles(
+    page: number = 1,
+    pageSize: number = 20,
+  ): Observable<ApiResponse<UnlinkedFile[]>> {
+    return this.api.get<UnlinkedFile[]>('admin/media/unlinked-files', { page, pageSize });
+  }
+
+  /**
+   * T015: PUT /api/v1/admin/media/{mediaId}/files/{fileId}/link — set MediaFile.MediaId = mediaId.
+   */
+  linkFile(mediaId: string, fileId: string): Observable<ApiResponse<void>> {
+    return this.api.put<void>(`admin/media/${mediaId}/files/${fileId}/link`, null);
+  }
+
+  /**
+   * T015: DELETE /api/v1/admin/media/{mediaId}/files/{fileId}/link — clear MediaFile.MediaId.
+   */
+  unlinkFile(mediaId: string, fileId: string): Observable<ApiResponse<void>> {
+    return this.api.delete<void>(`admin/media/${mediaId}/files/${fileId}/link`);
+  }
+
+  /**
+   * T025: PATCH /api/v1/admin/media/{mediaId}/root-folder — set or clear the manual root folder override.
+   */
+  updateRootFolder(mediaId: string, rootFolder: string | null): Observable<ApiResponse<void>> {
+    return this.api.patch<void>(`admin/media/${mediaId}/root-folder`, { rootFolder });
+  }
+}

--- a/src/app/features/collection/collection-stats.component.html
+++ b/src/app/features/collection/collection-stats.component.html
@@ -5,11 +5,11 @@
       <span class="stats-bar__label">{{ 'collection.stats.total' | transloco }}</span>
     </div>
     <div class="stats-bar__item">
-      <span class="stats-bar__value">{{ stats()!.totalFilms }}</span>
+      <span class="stats-bar__value">{{ stats()!.films }}</span>
       <span class="stats-bar__label">{{ 'collection.stats.films' | transloco }}</span>
     </div>
     <div class="stats-bar__item">
-      <span class="stats-bar__value">{{ stats()!.totalTvShows }}</span>
+      <span class="stats-bar__value">{{ stats()!.tvShows }}</span>
       <span class="stats-bar__label">{{ 'collection.stats.tvShows' | transloco }}</span>
     </div>
     @if (stats()!.incompleteTvShowCount > 0) {
@@ -22,11 +22,11 @@
       </div>
     }
     <div class="stats-bar__item">
-      <span class="stats-bar__value">{{ stats()!.totalWatched }}</span>
+      <span class="stats-bar__value">{{ stats()!.watchedByCurrentUser }}</span>
       <span class="stats-bar__label">{{ 'collection.stats.watched' | transloco }}</span>
     </div>
     <div class="stats-bar__item">
-      <span class="stats-bar__value">{{ stats()!.totalUnwatched }}</span>
+      <span class="stats-bar__value">{{ stats()!.unwatchedByCurrentUser }}</span>
       <span class="stats-bar__label">{{ 'collection.stats.unwatched' | transloco }}</span>
     </div>
   </div>

--- a/src/app/features/collection/media-card.component.spec.ts
+++ b/src/app/features/collection/media-card.component.spec.ts
@@ -31,6 +31,7 @@ const makeMedia = (posterPath: string | null = '/poster.jpg'): Media => ({
   status: null,
   numberOfSeasons: null,
   ownedSeasonCount: null,
+  rootFolder: null,
 });
 
 // ── IntersectionObserver mock ─────────────────────────────────────────────────

--- a/src/app/features/media-detail/file-link-picker-dialog.component.html
+++ b/src/app/features/media-detail/file-link-picker-dialog.component.html
@@ -1,0 +1,82 @@
+<p-dialog
+  [visible]="visible()"
+  [modal]="true"
+  [closable]="true"
+  [draggable]="false"
+  [resizable]="false"
+  styleClass="file-link-picker-dialog"
+  [header]="'mediaDetail.filePicker.title' | transloco"
+  (onHide)="close()"
+>
+  @if (loading()) {
+    <div class="file-link-picker__loading">
+      <i class="pi pi-spin pi-spinner"></i>
+      <span>{{ 'common.loading' | transloco }}</span>
+    </div>
+  } @else if (error()) {
+    <div class="file-link-picker__error">
+      <i class="pi pi-exclamation-triangle"></i>
+      <span>{{ 'mediaDetail.filePicker.loadError' | transloco }}</span>
+      <p-button
+        [label]="'common.retry' | transloco"
+        severity="secondary"
+        size="small"
+        (onClick)="loadFiles()"
+      />
+    </div>
+  } @else if (!files().length) {
+    <div class="file-link-picker__empty">
+      <i class="pi pi-folder-open"></i>
+      <p>{{ 'mediaDetail.filePicker.empty' | transloco }}</p>
+    </div>
+  } @else {
+    <p-table
+      [value]="files()"
+      [lazy]="true"
+      [paginator]="true"
+      [rows]="pageSize()"
+      [totalRecords]="meta()?.totalCount ?? 0"
+      [rowsPerPageOptions]="[20, 50, 100]"
+      (onPage)="onPageChange($event)"
+      styleClass="p-datatable-sm"
+    >
+      <ng-template pTemplate="header">
+        <tr>
+          <th>{{ 'mediaDetail.filePicker.columnPath' | transloco }}</th>
+          <th class="file-link-picker__col-format">
+            {{ 'mediaDetail.filePicker.columnFormat' | transloco }}
+          </th>
+          <th class="file-link-picker__col-size">
+            {{ 'mediaDetail.filePicker.columnSize' | transloco }}
+          </th>
+          <th class="file-link-picker__col-action"></th>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-file>
+        <tr>
+          <td class="file-link-picker__path" [title]="file.filePath">{{ file.filePath }}</td>
+          <td>
+            @if (file.format) {
+              <p-tag
+                [value]="file.format.toUpperCase()"
+                severity="secondary"
+                styleClass="text-xs"
+              />
+            }
+            @if (file.resolution) {
+              <p-tag [value]="file.resolution" severity="info" styleClass="text-xs" />
+            }
+          </td>
+          <td class="file-link-picker__size">{{ file.fileSizeBytes | fileSize }}</td>
+          <td>
+            <p-button
+              [label]="'mediaDetail.filePicker.linkButton' | transloco"
+              size="small"
+              (onClick)="onLinkClick(file.id)"
+            />
+          </td>
+        </tr>
+      </ng-template>
+    </p-table>
+  }
+</p-dialog>

--- a/src/app/features/media-detail/file-link-picker-dialog.component.scss
+++ b/src/app/features/media-detail/file-link-picker-dialog.component.scss
@@ -1,0 +1,44 @@
+.file-link-picker {
+  &__loading,
+  &__error,
+  &__empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 2rem 1rem;
+    color: var(--color-text-secondary);
+    text-align: center;
+
+    i {
+      font-size: 1.5rem;
+    }
+  }
+
+  &__error {
+    color: var(--color-danger, #e53e3e);
+  }
+
+  &__path {
+    font-family: monospace;
+    font-size: 0.8rem;
+    max-width: 480px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__size {
+    white-space: nowrap;
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+  }
+
+  &__col-format,
+  &__col-size,
+  &__col-action {
+    width: 1%;
+    white-space: nowrap;
+  }
+}

--- a/src/app/features/media-detail/file-link-picker-dialog.component.spec.ts
+++ b/src/app/features/media-detail/file-link-picker-dialog.component.spec.ts
@@ -1,0 +1,111 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { FileLinkPickerDialogComponent } from './file-link-picker-dialog.component';
+import { UnlinkedFile } from '@shared/models/media.model';
+import { environment } from '@env/environment';
+
+const base = environment.apiBaseUrl;
+
+function makeFile(partial?: Partial<UnlinkedFile>): UnlinkedFile {
+  return {
+    id: 'file-1',
+    filePath: '/nas/movies/Inception.mkv',
+    fileSizeBytes: 4294967296,
+    format: 'mkv',
+    resolution: '1080p',
+    ...partial,
+  };
+}
+
+describe('FileLinkPickerDialogComponent', () => {
+  let fixture: ComponentFixture<FileLinkPickerDialogComponent>;
+  let component: FileLinkPickerDialogComponent;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        FileLinkPickerDialogComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en: {}, fr: {} },
+          translocoConfig: { availableLangs: ['en', 'fr'], defaultLang: 'en' },
+        }),
+      ],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FileLinkPickerDialogComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  function flushUnlinkedFiles(files: UnlinkedFile[]): void {
+    const req = httpMock.expectOne((r) => r.url === `${base}/admin/media/unlinked-files`);
+    req.flush({
+      data: files,
+      meta: { page: 1, pageSize: 20, totalCount: files.length, totalPages: 1 },
+    });
+    fixture.detectChanges();
+  }
+
+  it('creates the component', () => {
+    fixture.detectChanges();
+    flushUnlinkedFiles([]);
+    expect(component).toBeTruthy();
+  });
+
+  it('loads unlinked files on init', () => {
+    fixture.detectChanges();
+    const files = [makeFile(), makeFile({ id: 'file-2', filePath: '/nas/movies/Avatar.mkv' })];
+    flushUnlinkedFiles(files);
+    expect(component.files()).toHaveLength(2);
+  });
+
+  it('sets loading to false after response', () => {
+    fixture.detectChanges();
+    expect(component.loading()).toBe(true);
+    flushUnlinkedFiles([]);
+    expect(component.loading()).toBe(false);
+  });
+
+  it('sets error when request fails', () => {
+    fixture.detectChanges();
+    const req = httpMock.expectOne((r) => r.url === `${base}/admin/media/unlinked-files`);
+    req.error(new ProgressEvent('error'));
+    fixture.detectChanges();
+    expect(component.error()).toBeTruthy();
+  });
+
+  it('emits fileLinkRequested with fileId on link click', () => {
+    const emitted: string[] = [];
+    component.fileLinkRequested.subscribe((id) => emitted.push(id));
+    fixture.detectChanges();
+    flushUnlinkedFiles([makeFile()]);
+    component.onLinkClick('file-1');
+    expect(emitted).toEqual(['file-1']);
+  });
+
+  it('emits visibleChange(false) on close', () => {
+    const emitted: boolean[] = [];
+    component.visibleChange.subscribe((v) => emitted.push(v));
+    fixture.detectChanges();
+    flushUnlinkedFiles([]);
+    component.close();
+    expect(emitted).toEqual([false]);
+  });
+
+  it('shows empty state when no files', () => {
+    fixture.detectChanges();
+    flushUnlinkedFiles([]);
+    const empty = fixture.nativeElement.querySelector('.file-link-picker__empty');
+    // With NO_ERRORS_SCHEMA the p-dialog is not rendered, but component state is verifiable
+    expect(component.files()).toHaveLength(0);
+    expect(component.error()).toBeNull();
+  });
+});

--- a/src/app/features/media-detail/file-link-picker-dialog.component.ts
+++ b/src/app/features/media-detail/file-link-picker-dialog.component.ts
@@ -1,0 +1,84 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  input,
+  OnInit,
+  output,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TranslocoModule } from '@jsverse/transloco';
+import { AdminMediaFileLinkService } from '@core/services/admin-media-file-link.service';
+import { UnlinkedFile } from '@shared/models/media.model';
+import { FileSizePipe } from '@shared/pipes/file-size.pipe';
+import { ButtonModule } from 'primeng/button';
+import { DialogModule } from 'primeng/dialog';
+import { TableModule } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { PaginationMeta } from '@core/api/api-response.model';
+
+@Component({
+  selector: 'app-file-link-picker-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [TranslocoModule, ButtonModule, DialogModule, TableModule, TagModule, FileSizePipe],
+  templateUrl: './file-link-picker-dialog.component.html',
+  styleUrl: './file-link-picker-dialog.component.scss',
+})
+export class FileLinkPickerDialogComponent implements OnInit {
+  /** Controls dialog visibility */
+  readonly visible = input<boolean>(false);
+  /** Emitted when the dialog should be closed */
+  readonly visibleChange = output<boolean>();
+  /** Emitted when a file is chosen to be linked, carries the fileId */
+  readonly fileLinkRequested = output<string>();
+
+  private readonly linkService = inject(AdminMediaFileLinkService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly files = signal<UnlinkedFile[]>([]);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly page = signal(1);
+  readonly pageSize = signal(20);
+  readonly meta = signal<PaginationMeta | null>(null);
+
+  ngOnInit(): void {
+    this.loadFiles();
+  }
+
+  loadFiles(): void {
+    this.loading.set(true);
+    this.error.set(null);
+    this.linkService
+      .getUnlinkedFiles(this.page(), this.pageSize())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          this.files.set(response.data ?? []);
+          this.meta.set(response.meta);
+          this.loading.set(false);
+        },
+        error: () => {
+          this.error.set('mediaDetail.filePicker.loadError');
+          this.loading.set(false);
+        },
+      });
+  }
+
+  onPageChange(event: { first: number; rows: number }): void {
+    this.page.set(Math.floor(event.first / event.rows) + 1);
+    this.pageSize.set(event.rows);
+    this.loadFiles();
+  }
+
+  onLinkClick(fileId: string): void {
+    this.fileLinkRequested.emit(fileId);
+  }
+
+  close(): void {
+    this.visibleChange.emit(false);
+  }
+}

--- a/src/app/features/media-detail/media-detail-page.component.html
+++ b/src/app/features/media-detail/media-detail-page.component.html
@@ -7,7 +7,6 @@
     <a routerLink="/" class="detail-page__back" [attr.aria-label]="'common.back' | transloco">
       <i class="pi pi-arrow-left" aria-hidden="true"></i> {{ 'common.back' | transloco }}
     </a>
-
     <!-- ── Cinematic hero section with parallax backdrop ── -->
     @if (media.backdropPath | tmdbImage: 'w1280'; as backdropUrl) {
       <div class="detail-page__hero" @heroEnter>
@@ -30,7 +29,6 @@
         </div>
       </div>
     }
-
     <!-- ── Poster + metadata row ── -->
     <div class="detail-page__content" @contentEnter>
       <div class="detail-page__poster-col">
@@ -49,7 +47,6 @@
           </div>
         }
       </div>
-
       <div class="detail-page__meta">
         <div class="detail-page__header">
           <!-- Use H1 only when there is no hero backdrop to avoid duplicate H1 -->
@@ -87,7 +84,6 @@
             </div>
           }
         </div>
-
         <div class="detail-page__details">
           @if (media.releaseDate) {
             <div class="detail-item">
@@ -114,7 +110,6 @@
             </div>
           }
         </div>
-
         @if (media.genres?.length) {
           <div class="detail-page__genres">
             @for (genre of media.genres; track genre) {
@@ -122,14 +117,12 @@
             }
           </div>
         }
-
         @if (media.overview) {
           <div class="detail-page__overview">
             <h3>{{ 'media.overview' | transloco }}</h3>
             <p>{{ media.overview }}</p>
           </div>
         }
-
         <div class="detail-page__watched-action">
           <p-button
             [icon]="media.userMedia?.isWatched ? 'pi pi-eye-slash' : 'pi pi-eye'"
@@ -147,8 +140,13 @@
         </div>
       </div>
     </div>
-
-    <!-- TV Show: season list -->
+    <!-- Root folder section (US2) -->
+    <app-root-folder
+      [rootFolder]="media.rootFolder"
+      [isAdmin]="isAdmin()"
+      (rootFolderSaved)="onRootFolderSaved($event)"
+    />
+    <!-- TV Show: season list + completeness + files merged -->
     @if (media.type === MediaType.TvShow) {
       <div class="detail-page__seasons">
         @if (service.seasonsLoading()) {
@@ -165,31 +163,41 @@
           />
         }
       </div>
+      <!-- Completeness + Files unified section (US3) -->
+      <div class="detail-page__tv-content">
+        <app-season-completeness
+          [completeness]="service.completeness()"
+          [loading]="service.completenessLoading()"
+          [files]="media.files ?? []"
+          [isAdmin]="isAdmin()"
+          (linkFileRequested)="onOpenLinkPicker()"
+          (unlinkFileRequested)="onUnlinkFileRequested($event)"
+        />
+        @if (service.filesError()) {
+          <app-error-message [message]="service.filesError()!" (retry)="reload()" />
+        }
+      </div>
     }
-
-    <!-- Files accordion — always at the bottom -->
-    <div class="detail-page__files-accordion">
-      <button
-        class="detail-page__files-header"
-        (click)="toggleFiles()"
-        [attr.aria-expanded]="filesOpen()"
-        [attr.aria-label]="'media.files' | transloco"
-        type="button"
-      >
-        <h3>{{ 'media.files' | transloco }}</h3>
-        <i
-          class="pi"
-          [class.pi-chevron-down]="!filesOpen()"
-          [class.pi-chevron-up]="filesOpen()"
-        ></i>
-      </button>
-      <div class="detail-page__files-body" [@accordionExpand]="filesOpen() ? 'open' : 'closed'">
+    <!-- Films: files section directly visible -->
+    @if (media.type === MediaType.Film) {
+      <div class="detail-page__film-files">
         @if (service.filesError()) {
           <app-error-message [message]="service.filesError()!" (retry)="reload()" />
         } @else {
-          <app-media-files [files]="media.files ?? []" />
+          <app-media-files
+            [files]="media.files ?? []"
+            [isAdmin]="isAdmin()"
+            (linkFileRequested)="onOpenLinkPicker()"
+            (unlinkFileRequested)="onUnlinkFileRequested($event)"
+          />
         }
       </div>
-    </div>
+    }
   </div>
+  <!-- File link picker dialog (US1) -->
+  <app-file-link-picker-dialog
+    [visible]="fileLinkPickerOpen()"
+    (visibleChange)="fileLinkPickerOpen.set($event)"
+    (fileLinkRequested)="onFileLinkRequested($event)"
+  />
 }

--- a/src/app/features/media-detail/media-detail-page.component.scss
+++ b/src/app/features/media-detail/media-detail-page.component.scss
@@ -220,52 +220,14 @@
 
 // Remaining detail page styles continue below
 .detail-page {
-  &__files-accordion {
-    margin-bottom: 1.5rem;
+  &__tv-content {
+    margin-top: 1rem;
   }
 
-  &__files-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    padding: 1rem 1.5rem;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
-    cursor: pointer;
-    user-select: none;
-    transition: background var(--anim-fast) var(--anim-easing);
-    color: var(--color-text-primary);
-
-    &:hover {
-      background: var(--color-bg-elevated);
-    }
-    &:focus-visible {
-      outline: 2px solid var(--color-accent);
-      outline-offset: 2px;
-    }
-    i {
-      color: var(--color-accent);
-    }
-
-    h3 {
-      margin: 0;
-      font-family: var(--font-display);
-      font-size: 1rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: var(--color-text-secondary);
-    }
-  }
-
-  &__files-body {
-    padding: 1rem 1.5rem;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--color-border);
-    border-top: none;
-    border-radius: 0 0 8px 8px;
-    overflow: hidden;
+  &__film-files {
+    margin-top: 1rem;
+    border-top: 1px solid var(--color-border);
+    padding-top: 1rem;
   }
 }
 

--- a/src/app/features/media-detail/media-detail-page.component.ts
+++ b/src/app/features/media-detail/media-detail-page.component.ts
@@ -10,16 +10,7 @@ import {
   OnInit,
   signal,
 } from '@angular/core';
-import {
-  animate,
-  group,
-  query,
-  stagger,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
+import { animate, style, transition, trigger } from '@angular/animations';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { ANIMATION_TIMINGS } from '@shared/animations/animation.config';
@@ -27,12 +18,16 @@ import { ErrorMessageComponent } from '@shared/components/error-message.componen
 import { LoadingSkeletonComponent } from '@shared/components/loading-skeleton.component';
 import { MediaType } from '@shared/models/enums';
 import { TmdbImagePipe } from '@shared/pipes/tmdb-image.pipe';
+import { AuthService } from '@core/auth/auth.service';
 import { ButtonModule } from 'primeng/button';
 import { ChipModule } from 'primeng/chip';
 import { TagModule } from 'primeng/tag';
 import { MediaDetailService } from './media-detail.service';
 import { MediaFilesComponent } from './media-files.component';
 import { SeasonListComponent } from './season-list.component';
+import { FileLinkPickerDialogComponent } from './file-link-picker-dialog.component';
+import { RootFolderComponent } from './root-folder.component';
+import { SeasonCompletenessComponent } from './season-completeness.component';
 
 @Component({
   selector: 'app-media-detail-page',
@@ -48,6 +43,9 @@ import { SeasonListComponent } from './season-list.component';
     ChipModule,
     MediaFilesComponent,
     SeasonListComponent,
+    FileLinkPickerDialogComponent,
+    RootFolderComponent,
+    SeasonCompletenessComponent,
     LoadingSkeletonComponent,
     ErrorMessageComponent,
     TmdbImagePipe,
@@ -55,12 +53,6 @@ import { SeasonListComponent } from './season-list.component';
     DecimalPipe,
   ],
   animations: [
-    // Files section accordion
-    trigger('accordionExpand', [
-      state('closed', style({ height: '0', overflow: 'hidden', opacity: 0 })),
-      state('open', style({ height: '*', overflow: 'hidden', opacity: 1 })),
-      transition('closed <=> open', animate(ANIMATION_TIMINGS.NORMAL)),
-    ]),
     // Hero section entrance: fade in + slight scale from 1.02 → 1
     trigger('heroEnter', [
       transition(':enter', [
@@ -79,6 +71,7 @@ import { SeasonListComponent } from './season-list.component';
 })
 export class MediaDetailPageComponent implements OnInit {
   readonly service = inject(MediaDetailService);
+  private readonly authService = inject(AuthService);
 
   private readonly route = inject(ActivatedRoute);
   private readonly host = inject(ElementRef<HTMLElement>);
@@ -86,11 +79,19 @@ export class MediaDetailPageComponent implements OnInit {
 
   readonly MediaType = MediaType;
 
-  /** Controls the files accordion open/closed state. */
-  readonly filesOpen = signal(false);
+  /** Controls the file link picker dialog visibility. */
+  readonly fileLinkPickerOpen = signal(false);
+
+  /** True when the current user is an admin. */
+  readonly isAdmin = computed(() => this.authService.isAdmin());
 
   /** True when the current media is a TV show. */
   readonly isTvShow = computed(() => this.service.media()?.type === MediaType.TvShow);
+
+  /** Current media ID from route params for link/unlink actions. */
+  private get mediaId(): string {
+    return this.route.snapshot.paramMap.get('id')!;
+  }
 
   /**
    * Transloco key for the TV show production status badge.
@@ -140,10 +141,6 @@ export class MediaDetailPageComponent implements OnInit {
     });
   };
 
-  toggleFiles(): void {
-    this.filesOpen.update((v) => !v);
-  }
-
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id')!;
     this.service.loadMedia(id);
@@ -191,6 +188,27 @@ export class MediaDetailPageComponent implements OnInit {
     for (const episodeId of event.episodeIds) {
       this.service.toggleEpisodeWatched(event.mediaId, event.seasonId, episodeId, event.isWatched);
     }
+  }
+
+  /** T019: Open the file link picker dialog. */
+  onOpenLinkPicker(): void {
+    this.fileLinkPickerOpen.set(true);
+  }
+
+  /** T019: Handle file link selection from the picker dialog. */
+  onFileLinkRequested(fileId: string): void {
+    this.fileLinkPickerOpen.set(false);
+    this.service.linkFile(this.mediaId, fileId);
+  }
+
+  /** T019: Handle unlink request from MediaFilesComponent. */
+  onUnlinkFileRequested(fileId: string): void {
+    this.service.unlinkFile(this.mediaId, fileId);
+  }
+
+  /** T028: Handle root folder save from RootFolderComponent. */
+  onRootFolderSaved(path: string | null): void {
+    this.service.updateRootFolder(this.mediaId, path);
   }
 
   reload(): void {

--- a/src/app/features/media-detail/media-detail.service.ts
+++ b/src/app/features/media-detail/media-detail.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { ApiService } from '@core/api/api.service';
-import { Media } from '@shared/models/media.model';
+import { AdminMediaFileLinkService } from '@core/services/admin-media-file-link.service';
+import { Media, SeasonCompleteness } from '@shared/models/media.model';
 import { TvSeason } from '@shared/models/tv.model';
 import { UserMedia } from '@shared/models/user.model';
 import { MediaType } from '@shared/models/enums';
@@ -9,6 +10,7 @@ import { finalize } from 'rxjs';
 @Injectable({ providedIn: 'root' })
 export class MediaDetailService {
   private readonly api = inject(ApiService);
+  private readonly fileLinkService = inject(AdminMediaFileLinkService);
 
   readonly media = signal<Media | null>(null);
   readonly seasons = signal<TvSeason[]>([]);
@@ -19,6 +21,12 @@ export class MediaDetailService {
   readonly seasonsError = signal<string | null>(null);
   /** Set when media files data is missing or malformed */
   readonly filesError = signal<string | null>(null);
+  /** Season completeness data (TV shows only) */
+  readonly completeness = signal<SeasonCompleteness[]>([]);
+  /** Loading state for completeness data */
+  readonly completenessLoading = signal(false);
+  /** Error state for completeness data */
+  readonly completenessError = signal<string | null>(null);
 
   loadMedia(id: string): void {
     this.loading.set(true);
@@ -40,6 +48,7 @@ export class MediaDetailService {
           this.media.set(safeMedia);
           if (safeMedia.type === MediaType.TvShow) {
             this.loadSeasons(id);
+            this.loadCompleteness(id);
           }
         },
         error: () => this.error.set('Failed to load media details'),
@@ -55,6 +64,19 @@ export class MediaDetailService {
       .subscribe({
         next: (response) => this.seasons.set(response.data ?? []),
         error: () => this.seasonsError.set('Failed to load seasons'),
+      });
+  }
+
+  /** T034: Load per-season completeness for a TV show. */
+  loadCompleteness(mediaId: string): void {
+    this.completenessLoading.set(true);
+    this.completenessError.set(null);
+    this.api
+      .get<SeasonCompleteness[]>(`media/${mediaId}/completeness`)
+      .pipe(finalize(() => this.completenessLoading.set(false)))
+      .subscribe({
+        next: (response) => this.completeness.set(response.data ?? []),
+        error: () => this.completenessError.set('Failed to load completeness data'),
       });
   }
 
@@ -94,5 +116,29 @@ export class MediaDetailService {
           );
         },
       });
+  }
+
+  /** T017: Link an unlinked MediaFile to this media, then refresh. */
+  linkFile(mediaId: string, fileId: string): void {
+    this.fileLinkService.linkFile(mediaId, fileId).subscribe({
+      next: () => this.loadMedia(mediaId),
+      error: () => this.filesError.set('Failed to link file'),
+    });
+  }
+
+  /** T017: Unlink a MediaFile from this media, then refresh. */
+  unlinkFile(mediaId: string, fileId: string): void {
+    this.fileLinkService.unlinkFile(mediaId, fileId).subscribe({
+      next: () => this.loadMedia(mediaId),
+      error: () => this.filesError.set('Failed to unlink file'),
+    });
+  }
+
+  /** T027: Update the root folder override for this media, then refresh. */
+  updateRootFolder(mediaId: string, path: string | null): void {
+    this.fileLinkService.updateRootFolder(mediaId, path).subscribe({
+      next: () => this.loadMedia(mediaId),
+      error: () => this.error.set('Failed to update root folder'),
+    });
   }
 }

--- a/src/app/features/media-detail/media-files.component.html
+++ b/src/app/features/media-detail/media-files.component.html
@@ -1,6 +1,17 @@
 <div class="media-files">
-  <h3>{{ 'media.files' | transloco }}</h3>
-
+  <div class="media-files__header">
+    <h3>{{ 'media.files' | transloco }}</h3>
+    @if (isAdmin()) {
+      <p-button
+        icon="pi pi-link"
+        [label]="'mediaDetail.fileLink.linkFileButton' | transloco"
+        size="small"
+        severity="secondary"
+        variant="outlined"
+        (onClick)="onLinkFileClick()"
+      />
+    }
+  </div>
   @if (!files().length) {
     <p class="text-color-secondary">{{ 'media.noFiles' | transloco }}</p>
   } @else {
@@ -32,6 +43,26 @@
               [attr.aria-label]="'common.copyPath' | transloco"
               (onClick)="copyPath(file.filePath)"
             />
+            <p-button
+              icon="pi pi-folder-open"
+              size="small"
+              variant="text"
+              severity="secondary"
+              [pTooltip]="'common.copyFolderPath' | transloco"
+              [attr.aria-label]="'common.copyFolderPath' | transloco"
+              (onClick)="copyFolder(file.filePath)"
+            />
+            @if (isAdmin()) {
+              <p-button
+                icon="pi pi-unlink"
+                size="small"
+                variant="text"
+                severity="danger"
+                [pTooltip]="'mediaDetail.fileLink.unlinkButton' | transloco"
+                [attr.aria-label]="'mediaDetail.fileLink.unlinkButton' | transloco"
+                (onClick)="onUnlinkClick(file.id)"
+              />
+            }
           </div>
           @if (fallbackPaths()[file.filePath]) {
             <div class="media-files__fallback">
@@ -50,6 +81,27 @@
                   variant="text"
                   severity="secondary"
                   (onClick)="clearFallback(file.filePath)"
+                />
+              </div>
+            </div>
+          }
+          @if (fallbackFolders()[file.filePath]) {
+            <div class="media-files__fallback">
+              <p class="media-files__fallback-label">{{ 'media.copyFallbackLabel' | transloco }}</p>
+              <div class="media-files__fallback-row">
+                <textarea
+                  readonly
+                  [value]="getFolderPath(file.filePath)"
+                  class="media-files__fallback-textarea"
+                  [attr.aria-label]="'media.copyFallbackLabel' | transloco"
+                  rows="2"
+                ></textarea>
+                <p-button
+                  icon="pi pi-times"
+                  size="small"
+                  variant="text"
+                  severity="secondary"
+                  (onClick)="clearFolderFallback(file.filePath)"
                 />
               </div>
             </div>

--- a/src/app/features/media-detail/media-files.component.ts
+++ b/src/app/features/media-detail/media-files.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, output, signal } from '@angular/core';
 import { ClipboardService } from '@core/services/clipboard.service';
 import { TranslocoModule } from '@jsverse/transloco';
 import { MediaFile } from '@shared/models/media.model';
@@ -18,16 +18,24 @@ import { FormsModule } from '@angular/forms';
 export class MediaFilesComponent {
   /** T120: Accept null/undefined gracefully — defaults to empty array. */
   readonly files = input<MediaFile[]>([]);
+  /** Whether the current user is admin — controls Unlink/Link buttons visibility. */
+  readonly isAdmin = input<boolean>(false);
+
+  /** Emitted when the admin clicks "Link File" (open picker dialog). */
+  readonly linkFileRequested = output<void>();
+  /** Emitted when the admin clicks "Unlink" on a specific file. */
+  readonly unlinkFileRequested = output<string>();
 
   private readonly clipboard = inject(ClipboardService);
 
   /** Tracks which file paths are showing the fallback textarea */
   readonly fallbackPaths = signal<Record<string, boolean>>({});
+  /** Tracks which folder paths are showing the folder-copy fallback textarea */
+  readonly fallbackFolders = signal<Record<string, boolean>>({});
 
   async copyPath(path: string): Promise<void> {
     const success = await this.clipboard.copy(path);
     if (!success) {
-      // On clipboard rejection, show fallback textarea for manual copying
       this.fallbackPaths.update((m) => ({ ...m, [path]: true }));
     }
   }
@@ -38,5 +46,34 @@ export class MediaFilesComponent {
       delete next[path];
       return next;
     });
+  }
+
+  getFolderPath(filePath: string): string {
+    const lastSlash = filePath.lastIndexOf('/');
+    return lastSlash > 0 ? filePath.substring(0, lastSlash) : filePath;
+  }
+
+  async copyFolder(filePath: string): Promise<void> {
+    const folder = this.getFolderPath(filePath);
+    const success = await this.clipboard.copy(folder);
+    if (!success) {
+      this.fallbackFolders.update((m) => ({ ...m, [filePath]: true }));
+    }
+  }
+
+  clearFolderFallback(filePath: string): void {
+    this.fallbackFolders.update((m) => {
+      const next = { ...m };
+      delete next[filePath];
+      return next;
+    });
+  }
+
+  onUnlinkClick(fileId: string): void {
+    this.unlinkFileRequested.emit(fileId);
+  }
+
+  onLinkFileClick(): void {
+    this.linkFileRequested.emit();
   }
 }

--- a/src/app/features/media-detail/root-folder.component.html
+++ b/src/app/features/media-detail/root-folder.component.html
@@ -1,0 +1,119 @@
+<div class="root-folder">
+  <h3 class="root-folder__title">{{ 'mediaDetail.rootFolder.title' | transloco }}</h3>
+  @if (rootFolder()) {
+    @if (!editing()) {
+      <div class="root-folder__path-row">
+        <i class="pi pi-folder root-folder__icon" aria-hidden="true"></i>
+        <span class="root-folder__path" [title]="rootFolder()!">{{ rootFolder() }}</span>
+        <p-button
+          icon="pi pi-copy"
+          size="small"
+          variant="text"
+          severity="secondary"
+          [pTooltip]="'mediaDetail.rootFolder.copyTooltip' | transloco"
+          [attr.aria-label]="'mediaDetail.rootFolder.copyTooltip' | transloco"
+          (onClick)="copyPath()"
+        />
+        @if (isAdmin()) {
+          <p-button
+            icon="pi pi-pencil"
+            size="small"
+            variant="text"
+            severity="secondary"
+            [pTooltip]="'mediaDetail.rootFolder.editTooltip' | transloco"
+            [attr.aria-label]="'mediaDetail.rootFolder.editTooltip' | transloco"
+            (onClick)="startEdit()"
+          />
+        }
+      </div>
+      @if (showFallback()) {
+        <div class="root-folder__fallback">
+          <p class="root-folder__fallback-label">{{ 'media.copyFallbackLabel' | transloco }}</p>
+          <div class="root-folder__fallback-row">
+            <textarea
+              readonly
+              [value]="rootFolder()!"
+              class="root-folder__fallback-textarea"
+              rows="2"
+              [attr.aria-label]="'media.copyFallbackLabel' | transloco"
+            ></textarea>
+            <p-button
+              icon="pi pi-times"
+              size="small"
+              variant="text"
+              severity="secondary"
+              (onClick)="clearFallback()"
+            />
+          </div>
+        </div>
+      }
+    } @else {
+      <div class="root-folder__edit-row">
+        <input
+          class="root-folder__edit-input"
+          type="text"
+          [ngModel]="editValue()"
+          (ngModelChange)="editValue.set($event)"
+          [placeholder]="'mediaDetail.rootFolder.inputPlaceholder' | transloco"
+          [attr.aria-label]="'mediaDetail.rootFolder.inputPlaceholder' | transloco"
+        />
+        <p-button
+          icon="pi pi-check"
+          size="small"
+          severity="success"
+          [pTooltip]="'common.save' | transloco"
+          (onClick)="saveEdit()"
+        />
+        <p-button
+          icon="pi pi-times"
+          size="small"
+          severity="secondary"
+          variant="text"
+          [pTooltip]="'common.cancel' | transloco"
+          (onClick)="cancelEdit()"
+        />
+      </div>
+    }
+  } @else {
+    <div class="root-folder__empty">
+      <span class="text-color-secondary">{{ 'mediaDetail.rootFolder.empty' | transloco }}</span>
+      @if (isAdmin()) {
+        <p-button
+          icon="pi pi-pencil"
+          [label]="'mediaDetail.rootFolder.setButton' | transloco"
+          size="small"
+          variant="text"
+          severity="secondary"
+          (onClick)="startEdit()"
+        />
+      }
+    </div>
+    @if (editing()) {
+      <div class="root-folder__edit-row">
+        <input
+          class="root-folder__edit-input"
+          type="text"
+          [ngModel]="editValue()"
+          (ngModelChange)="editValue.set($event)"
+          [placeholder]="'mediaDetail.rootFolder.inputPlaceholder' | transloco"
+          [attr.aria-label]="'mediaDetail.rootFolder.inputPlaceholder' | transloco"
+        />
+        <p-button
+          icon="pi pi-check"
+          size="small"
+          severity="success"
+          [pTooltip]="'common.save' | transloco"
+          (onClick)="saveEdit()"
+        />
+        <p-button
+          icon="pi pi-times"
+          size="small"
+          severity="secondary"
+          variant="text"
+          [pTooltip]="'common.cancel' | transloco"
+          (onClick)="cancelEdit()"
+        />
+      </div>
+    }
+  }
+</div>

--- a/src/app/features/media-detail/root-folder.component.scss
+++ b/src/app/features/media-detail/root-folder.component.scss
@@ -1,18 +1,9 @@
-.media-files {
-  &__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-bottom: 1rem;
+.root-folder {
+  padding: 1rem 0;
+  border-top: 1px solid var(--color-border);
 
-    h3 {
-      margin: 0;
-    }
-  }
-
-  h3 {
-    margin: 0 0 1rem;
+  &__title {
+    margin: 0 0 0.75rem;
     font-family: var(--font-display);
     font-size: 1rem;
     letter-spacing: 0.06em;
@@ -20,67 +11,64 @@
     color: var(--color-text-secondary);
   }
 
-  &__list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  &__item {
+  &__path-row {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    padding: 0.5rem 0.75rem;
-    background: var(--color-bg-elevated);
-    border-radius: 6px;
-    border: 1px solid var(--color-border);
+    gap: 0.5rem;
     flex-wrap: wrap;
   }
 
-  &__path {
-    display: flex;
-    align-items: center;
-    flex: 1;
-    min-width: 0;
+  &__icon {
     color: var(--color-text-secondary);
-
-    i {
-      flex-shrink: 0;
-      margin-right: 0.5rem;
-    }
+    flex-shrink: 0;
   }
 
-  &__path-text {
+  &__path {
     font-family: monospace;
     font-size: 0.85rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    flex: 1;
+    min-width: 0;
     color: var(--color-text-primary);
   }
 
-  &__meta {
+  &__empty {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    flex-shrink: 0;
     color: var(--color-text-secondary);
     font-size: 0.875rem;
   }
 
-  &__empty {
-    color: var(--color-text-secondary);
-    font-family: var(--font-body);
-    margin: 0;
+  &__edit-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  &__edit-input {
+    flex: 1;
+    min-width: 200px;
+    padding: 0.375rem 0.625rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg-surface);
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+    font-family: monospace;
+
+    &:focus {
+      outline: 2px solid var(--p-primary-color, #6366f1);
+      outline-offset: 1px;
+    }
   }
 
   &__fallback {
-    padding: 0.5rem 0 0;
-    width: 100%;
+    margin-top: 0.5rem;
   }
 
   &__fallback-label {

--- a/src/app/features/media-detail/root-folder.component.spec.ts
+++ b/src/app/features/media-detail/root-folder.component.spec.ts
@@ -1,0 +1,137 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { vi } from 'vitest';
+import { RootFolderComponent } from './root-folder.component';
+import { ClipboardService } from '@core/services/clipboard.service';
+
+describe('RootFolderComponent', () => {
+  let fixture: ComponentFixture<RootFolderComponent>;
+  let component: RootFolderComponent;
+
+  const clipboardSpy = { copy: vi.fn().mockResolvedValue(true) };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        RootFolderComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en: {}, fr: {} },
+          translocoConfig: { availableLangs: ['en', 'fr'], defaultLang: 'en' },
+        }),
+      ],
+      providers: [{ provide: ClipboardService, useValue: clipboardSpy }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RootFolderComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('creates the component', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  describe('initial state', () => {
+    it('editing starts false', () => {
+      fixture.detectChanges();
+      expect(component.editing()).toBe(false);
+    });
+
+    it('showFallback starts false', () => {
+      fixture.detectChanges();
+      expect(component.showFallback()).toBe(false);
+    });
+  });
+
+  describe('when rootFolder is set', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('rootFolder', '/nas/Movies/Breaking Bad');
+      fixture.detectChanges();
+    });
+
+    it('displays the path', () => {
+      expect(component.rootFolder()).toBe('/nas/Movies/Breaking Bad');
+    });
+
+    it('calls clipboard.copy on copyPath()', async () => {
+      await component.copyPath();
+      expect(clipboardSpy.copy).toHaveBeenCalledWith('/nas/Movies/Breaking Bad');
+    });
+
+    it('sets showFallback true when clipboard fails', async () => {
+      clipboardSpy.copy.mockResolvedValue(false);
+      await component.copyPath();
+      expect(component.showFallback()).toBe(true);
+    });
+
+    it('clearFallback resets showFallback', async () => {
+      clipboardSpy.copy.mockResolvedValue(false);
+      await component.copyPath();
+      component.clearFallback();
+      expect(component.showFallback()).toBe(false);
+    });
+  });
+
+  describe('when rootFolder is null', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('rootFolder', null);
+      fixture.detectChanges();
+    });
+
+    it('has null rootFolder', () => {
+      expect(component.rootFolder()).toBeNull();
+    });
+  });
+
+  describe('edit mode (admin)', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('rootFolder', '/nas/Movies');
+      fixture.componentRef.setInput('isAdmin', true);
+      fixture.detectChanges();
+    });
+
+    it('startEdit sets editing true and populates editValue', () => {
+      component.startEdit();
+      expect(component.editing()).toBe(true);
+      expect(component.editValue()).toBe('/nas/Movies');
+    });
+
+    it('cancelEdit resets editing to false', () => {
+      component.startEdit();
+      component.cancelEdit();
+      expect(component.editing()).toBe(false);
+    });
+
+    it('saveEdit emits rootFolderSaved with trimmed value', () => {
+      const emitted: (string | null)[] = [];
+      component.rootFolderSaved.subscribe((v) => emitted.push(v));
+      component.startEdit();
+      component.editValue.set('  /new/path  ');
+      component.saveEdit();
+      expect(emitted).toEqual(['/new/path']);
+      expect(component.editing()).toBe(false);
+    });
+
+    it('saveEdit emits null when edit value is empty', () => {
+      const emitted: (string | null)[] = [];
+      component.rootFolderSaved.subscribe((v) => emitted.push(v));
+      component.startEdit();
+      component.editValue.set('   ');
+      component.saveEdit();
+      expect(emitted).toEqual([null]);
+    });
+  });
+
+  describe('non-admin', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('isAdmin', false);
+      fixture.detectChanges();
+    });
+
+    it('isAdmin is false', () => {
+      expect(component.isAdmin()).toBe(false);
+    });
+  });
+});

--- a/src/app/features/media-detail/root-folder.component.ts
+++ b/src/app/features/media-detail/root-folder.component.ts
@@ -1,0 +1,58 @@
+import { ChangeDetectionStrategy, Component, inject, input, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TranslocoModule } from '@jsverse/transloco';
+import { ClipboardService } from '@core/services/clipboard.service';
+import { ButtonModule } from 'primeng/button';
+import { TooltipModule } from 'primeng/tooltip';
+
+@Component({
+  selector: 'app-root-folder',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [TranslocoModule, ButtonModule, TooltipModule, FormsModule],
+  templateUrl: './root-folder.component.html',
+  styleUrl: './root-folder.component.scss',
+})
+export class RootFolderComponent {
+  /** Effective root folder path (from media.rootFolder). Null when unknown. */
+  readonly rootFolder = input<string | null>(null);
+  /** Whether the current user is an admin (controls edit controls visibility). */
+  readonly isAdmin = input<boolean>(false);
+
+  /** Emitted when admin saves a new root folder value (null to clear override). */
+  readonly rootFolderSaved = output<string | null>();
+
+  private readonly clipboard = inject(ClipboardService);
+
+  readonly editing = signal(false);
+  readonly editValue = signal('');
+  readonly showFallback = signal(false);
+
+  async copyPath(): Promise<void> {
+    const path = this.rootFolder();
+    if (!path) return;
+    const success = await this.clipboard.copy(path);
+    if (!success) {
+      this.showFallback.set(true);
+    }
+  }
+
+  clearFallback(): void {
+    this.showFallback.set(false);
+  }
+
+  startEdit(): void {
+    this.editValue.set(this.rootFolder() ?? '');
+    this.editing.set(true);
+  }
+
+  cancelEdit(): void {
+    this.editing.set(false);
+  }
+
+  saveEdit(): void {
+    const trimmed = this.editValue().trim();
+    this.rootFolderSaved.emit(trimmed.length > 0 ? trimmed : null);
+    this.editing.set(false);
+  }
+}

--- a/src/app/features/media-detail/season-completeness.component.html
+++ b/src/app/features/media-detail/season-completeness.component.html
@@ -1,0 +1,191 @@
+<div class="season-completeness">
+  <div class="season-completeness__header">
+    <h3 class="season-completeness__title">{{ 'mediaDetail.completeness.title' | transloco }}</h3>
+    @if (isAdmin()) {
+      <p-button
+        icon="pi pi-link"
+        [label]="'mediaDetail.fileLink.linkFileButton' | transloco"
+        size="small"
+        severity="secondary"
+        variant="outlined"
+        (onClick)="onLinkFileClick()"
+      />
+    }
+  </div>
+  @if (loading()) {
+    <div class="season-completeness__loading">
+      <i class="pi pi-spin pi-spinner"></i>
+      <span>{{ 'common.loading' | transloco }}</span>
+    </div>
+  } @else if (!completeness().length) {
+    <p class="season-completeness__empty text-color-secondary">
+      {{ 'mediaDetail.completeness.noData' | transloco }}
+    </p>
+  } @else {
+    <ul class="season-completeness__list">
+      @for (season of completeness(); track season.seasonNumber) {
+        <li
+          class="season-completeness__item"
+          [class.season-completeness__item--complete]="season.isComplete"
+        >
+          <div class="season-completeness__row">
+            <button
+              class="season-completeness__toggle"
+              [attr.aria-expanded]="isExpanded(season.seasonNumber)"
+              (click)="toggleSeason(season.seasonNumber)"
+            >
+              <i
+                class="pi"
+                [class.pi-chevron-right]="!isExpanded(season.seasonNumber)"
+                [class.pi-chevron-down]="isExpanded(season.seasonNumber)"
+                aria-hidden="true"
+              ></i>
+              <span class="season-completeness__name">{{ season.seasonName }}</span>
+            </button>
+            <div class="season-completeness__badges">
+              <span class="season-completeness__count">
+                {{
+                  'mediaDetail.completeness.ownedOf'
+                    | transloco: { owned: season.ownedCount, total: season.totalExpected }
+                }}
+              </span>
+              @if (season.isComplete) {
+                <p-tag
+                  [value]="'mediaDetail.completeness.complete' | transloco"
+                  severity="success"
+                  icon="pi pi-check"
+                  styleClass="text-xs"
+                />
+              } @else {
+                <p-tag
+                  [value]="'mediaDetail.completeness.incomplete' | transloco"
+                  severity="warn"
+                  styleClass="text-xs"
+                />
+              }
+            </div>
+          </div>
+          @if (!season.isComplete && season.missingEpisodeNumbers.length) {
+            <p class="season-completeness__missing">
+              {{ 'mediaDetail.completeness.missingEpisodes' | transloco }}
+              <span class="season-completeness__missing-list">
+                {{ season.missingEpisodeNumbers.join(', ') }}
+              </span>
+            </p>
+          }
+          @if (isExpanded(season.seasonNumber)) {
+            @let seasonFiles = filesBySeason().get(season.seasonNumber) ?? [];
+            <div class="season-completeness__files">
+              @if (!seasonFiles.length) {
+                <p class="season-completeness__files-empty text-color-secondary">
+                  {{ 'media.noFiles' | transloco }}
+                </p>
+              } @else {
+                <ul class="season-completeness__files-list">
+                  @for (file of seasonFiles; track file.id) {
+                    <li class="season-completeness__file-item">
+                      <div class="season-completeness__file-path">
+                        <i class="pi pi-file mr-2 text-color-secondary" aria-hidden="true"></i>
+                        <span class="season-completeness__file-path-text" [title]="file.filePath">{{
+                          file.filePath
+                        }}</span>
+                      </div>
+                      <div class="season-completeness__file-meta">
+                        @if (file.format) {
+                          <p-tag
+                            [value]="file.format.toUpperCase()"
+                            severity="secondary"
+                            styleClass="text-xs"
+                          />
+                        }
+                        @if (file.resolution) {
+                          <p-tag [value]="file.resolution" severity="info" styleClass="text-xs" />
+                        }
+                        <span class="text-sm text-color-secondary">{{
+                          file.fileSizeBytes | fileSize
+                        }}</span>
+                        <p-button
+                          icon="pi pi-copy"
+                          size="small"
+                          variant="text"
+                          severity="secondary"
+                          [pTooltip]="'common.copyPath' | transloco"
+                          [attr.aria-label]="'common.copyPath' | transloco"
+                          (onClick)="copyPath(file.filePath)"
+                        />
+                        <p-button
+                          icon="pi pi-folder-open"
+                          size="small"
+                          variant="text"
+                          severity="secondary"
+                          [pTooltip]="'common.copyFolderPath' | transloco"
+                          [attr.aria-label]="'common.copyFolderPath' | transloco"
+                          (onClick)="copyFolder(file.filePath)"
+                        />
+                        @if (isAdmin()) {
+                          <p-button
+                            icon="pi pi-unlink"
+                            size="small"
+                            variant="text"
+                            severity="danger"
+                            [pTooltip]="'mediaDetail.fileLink.unlinkButton' | transloco"
+                            [attr.aria-label]="'mediaDetail.fileLink.unlinkButton' | transloco"
+                            (onClick)="onUnlinkClick(file.id)"
+                          />
+                        }
+                      </div>
+                      @if (fallbackPaths()[file.filePath]) {
+                        <div class="season-completeness__file-fallback">
+                          <p class="season-completeness__file-fallback-label">
+                            {{ 'media.copyFallbackLabel' | transloco }}
+                          </p>
+                          <div class="season-completeness__file-fallback-row">
+                            <textarea
+                              readonly
+                              [value]="file.filePath"
+                              rows="2"
+                              [attr.aria-label]="'media.copyFallbackLabel' | transloco"
+                            ></textarea>
+                            <p-button
+                              icon="pi pi-times"
+                              size="small"
+                              variant="text"
+                              severity="secondary"
+                              (onClick)="clearFallback(file.filePath)"
+                            />
+                          </div>
+                        </div>
+                      }
+                      @if (fallbackFolders()[file.filePath]) {
+                        <div class="season-completeness__file-fallback">
+                          <p class="season-completeness__file-fallback-label">
+                            {{ 'media.copyFallbackLabel' | transloco }}
+                          </p>
+                          <div class="season-completeness__file-fallback-row">
+                            <textarea
+                              readonly
+                              [value]="getFolderPath(file.filePath)"
+                              rows="2"
+                              [attr.aria-label]="'media.copyFallbackLabel' | transloco"
+                            ></textarea>
+                            <p-button
+                              icon="pi pi-times"
+                              size="small"
+                              variant="text"
+                              severity="secondary"
+                              (onClick)="clearFolderFallback(file.filePath)"
+                            />
+                          </div>
+                        </div>
+                      }
+                    </li>
+                  }
+                </ul>
+              }
+            </div>
+          }
+        </li>
+      }
+    </ul>
+  }
+</div>

--- a/src/app/features/media-detail/season-completeness.component.scss
+++ b/src/app/features/media-detail/season-completeness.component.scss
@@ -1,0 +1,187 @@
+.season-completeness {
+  padding: 1rem 0;
+  border-top: 1px solid var(--color-border);
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  &__title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 1rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-secondary);
+  }
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--color-text-secondary);
+  }
+
+  &__empty {
+    font-size: 0.875rem;
+    margin: 0;
+  }
+
+  &__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__item {
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg-elevated);
+
+    &--complete {
+      border-color: var(--p-green-500, #22c55e);
+    }
+  }
+
+  &__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  &__name {
+    font-weight: 600;
+    font-size: 0.9rem;
+  }
+
+  &__badges {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  &__count {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+  }
+
+  &__missing {
+    margin: 0.5rem 0 0;
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+  }
+
+  &__missing-list {
+    font-family: monospace;
+    color: var(--color-text-primary);
+  }
+
+  &__toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+
+    &:focus-visible {
+      outline: 2px solid var(--p-primary-color);
+      border-radius: 4px;
+    }
+
+    .pi {
+      font-size: 0.7rem;
+      color: var(--color-text-secondary);
+      flex-shrink: 0;
+    }
+  }
+
+  &__files {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--color-border);
+  }
+
+  &__files-empty {
+    font-size: 0.875rem;
+    margin: 0;
+  }
+
+  &__files-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__file-item {
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    background: var(--color-bg-base);
+    border: 1px solid var(--color-border);
+  }
+
+  &__file-path {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    min-width: 0;
+    margin-bottom: 0.25rem;
+  }
+
+  &__file-path-text {
+    font-size: 0.8rem;
+    font-family: monospace;
+    color: var(--color-text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__file-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+  }
+
+  &__file-fallback {
+    margin-top: 0.5rem;
+
+    textarea {
+      width: 100%;
+      font-family: monospace;
+      font-size: 0.8rem;
+      resize: vertical;
+    }
+  }
+
+  &__file-fallback-label {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    margin: 0 0 0.25rem;
+  }
+
+  &__file-fallback-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}

--- a/src/app/features/media-detail/season-completeness.component.spec.ts
+++ b/src/app/features/media-detail/season-completeness.component.spec.ts
@@ -1,0 +1,135 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { SeasonCompletenessComponent } from './season-completeness.component';
+import { SeasonCompleteness } from '@shared/models/media.model';
+import { ClipboardService } from '@core/services/clipboard.service';
+
+function makeSeason(partial?: Partial<SeasonCompleteness>): SeasonCompleteness {
+  return {
+    seasonNumber: 1,
+    seasonName: 'Season 1',
+    totalExpected: 10,
+    ownedCount: 8,
+    missingEpisodeNumbers: [3, 7],
+    isComplete: false,
+    ...partial,
+  };
+}
+
+describe('SeasonCompletenessComponent', () => {
+  let fixture: ComponentFixture<SeasonCompletenessComponent>;
+  let component: SeasonCompletenessComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        SeasonCompletenessComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en: {}, fr: {} },
+          translocoConfig: { availableLangs: ['en', 'fr'], defaultLang: 'en' },
+        }),
+      ],
+      providers: [
+        {
+          provide: ClipboardService,
+          useValue: {
+            copy: async (): Promise<boolean> => true,
+          },
+        },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SeasonCompletenessComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('creates the component', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  describe('empty state', () => {
+    it('completeness defaults to empty array', () => {
+      fixture.detectChanges();
+      expect(component.completeness()).toEqual([]);
+    });
+
+    it('renders empty state when no seasons', () => {
+      fixture.componentRef.setInput('completeness', []);
+      fixture.detectChanges();
+      const empty = fixture.nativeElement.querySelector('.season-completeness__empty');
+      expect(empty).toBeTruthy();
+    });
+
+    it('does not render season list when empty', () => {
+      fixture.componentRef.setInput('completeness', []);
+      fixture.detectChanges();
+      const list = fixture.nativeElement.querySelector('.season-completeness__list');
+      expect(list).toBeNull();
+    });
+  });
+
+  describe('with completeness data', () => {
+    const seasons = [
+      makeSeason({ seasonNumber: 1, ownedCount: 8, totalExpected: 10, isComplete: false }),
+      makeSeason({
+        seasonNumber: 2,
+        seasonName: 'Season 2',
+        ownedCount: 8,
+        totalExpected: 8,
+        missingEpisodeNumbers: [],
+        isComplete: true,
+      }),
+    ];
+
+    beforeEach(() => {
+      fixture.componentRef.setInput('completeness', seasons);
+      fixture.detectChanges();
+    });
+
+    it('renders the season list', () => {
+      const list = fixture.nativeElement.querySelector('.season-completeness__list');
+      expect(list).toBeTruthy();
+    });
+
+    it('renders one item per season', () => {
+      const items = fixture.nativeElement.querySelectorAll('.season-completeness__item');
+      expect(items.length).toBe(2);
+    });
+
+    it('marks complete season with --complete modifier class', () => {
+      const items = fixture.nativeElement.querySelectorAll('.season-completeness__item');
+      expect(items[1].classList.contains('season-completeness__item--complete')).toBe(true);
+    });
+
+    it('does not mark incomplete season with --complete modifier class', () => {
+      const items = fixture.nativeElement.querySelectorAll('.season-completeness__item');
+      expect(items[0].classList.contains('season-completeness__item--complete')).toBe(false);
+    });
+
+    it('shows missing episode row for incomplete season', () => {
+      const missing = fixture.nativeElement.querySelectorAll('.season-completeness__missing');
+      expect(missing.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading indicator when loading is true', () => {
+      fixture.componentRef.setInput('loading', true);
+      fixture.componentRef.setInput('completeness', []);
+      fixture.detectChanges();
+      const loading = fixture.nativeElement.querySelector('.season-completeness__loading');
+      expect(loading).toBeTruthy();
+    });
+
+    it('does not show list when loading', () => {
+      fixture.componentRef.setInput('loading', true);
+      fixture.componentRef.setInput('completeness', [makeSeason()]);
+      fixture.detectChanges();
+      const list = fixture.nativeElement.querySelector('.season-completeness__list');
+      expect(list).toBeNull();
+    });
+  });
+});

--- a/src/app/features/media-detail/season-completeness.component.ts
+++ b/src/app/features/media-detail/season-completeness.component.ts
@@ -1,0 +1,111 @@
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
+import { ClipboardService } from '@core/services/clipboard.service';
+import { inject } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import { MediaFile, SeasonCompleteness } from '@shared/models/media.model';
+import { FileSizePipe } from '@shared/pipes/file-size.pipe';
+import { ButtonModule } from 'primeng/button';
+import { TagModule } from 'primeng/tag';
+import { TooltipModule } from 'primeng/tooltip';
+
+/** Regex to extract season number from episode filename (e.g. S01E02 or s1e2) */
+const SEASON_RE = /[Ss](\d{1,2})[Ee]\d/;
+
+@Component({
+  selector: 'app-season-completeness',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [TranslocoModule, TagModule, ButtonModule, TooltipModule, FileSizePipe],
+  templateUrl: './season-completeness.component.html',
+  styleUrl: './season-completeness.component.scss',
+})
+export class SeasonCompletenessComponent {
+  /** Completeness data for all seasons. Empty array when data not yet loaded. */
+  readonly completeness = input<SeasonCompleteness[]>([]);
+  /** Whether the completeness data is still loading. */
+  readonly loading = input<boolean>(false);
+  /** All linked files for this TV show. */
+  readonly files = input<MediaFile[]>([]);
+  /** Whether the current user is admin — controls Link/Unlink buttons. */
+  readonly isAdmin = input<boolean>(false);
+
+  readonly linkFileRequested = output<void>();
+  readonly unlinkFileRequested = output<string>();
+
+  private readonly clipboard = inject(ClipboardService);
+
+  /** Map from season number → files that match that season. */
+  readonly filesBySeason = computed<Map<number, MediaFile[]>>(() => {
+    const map = new Map<number, MediaFile[]>();
+    for (const file of this.files()) {
+      const match = SEASON_RE.exec(file.filePath);
+      const seasonNum = match ? parseInt(match[1], 10) : 0;
+      const list = map.get(seasonNum) ?? [];
+      list.push(file);
+      map.set(seasonNum, list);
+    }
+    return map;
+  });
+
+  /** Set of season numbers that are expanded. */
+  private readonly expandedSet = signal<Set<number>>(new Set());
+
+  isExpanded(seasonNumber: number): boolean {
+    return this.expandedSet().has(seasonNumber);
+  }
+
+  toggleSeason(seasonNumber: number): void {
+    this.expandedSet.update((s) => {
+      const next = new Set(s);
+      if (next.has(seasonNumber)) {
+        next.delete(seasonNumber);
+      } else {
+        next.add(seasonNumber);
+      }
+      return next;
+    });
+  }
+
+  readonly fallbackPaths = signal<Record<string, boolean>>({});
+  readonly fallbackFolders = signal<Record<string, boolean>>({});
+
+  async copyPath(path: string): Promise<void> {
+    const success = await this.clipboard.copy(path);
+    if (!success) this.fallbackPaths.update((m) => ({ ...m, [path]: true }));
+  }
+
+  clearFallback(path: string): void {
+    this.fallbackPaths.update((m) => {
+      const n = { ...m };
+      delete n[path];
+      return n;
+    });
+  }
+
+  getFolderPath(filePath: string): string {
+    const i = filePath.lastIndexOf('/');
+    return i > 0 ? filePath.substring(0, i) : filePath;
+  }
+
+  async copyFolder(filePath: string): Promise<void> {
+    const folder = this.getFolderPath(filePath);
+    const success = await this.clipboard.copy(folder);
+    if (!success) this.fallbackFolders.update((m) => ({ ...m, [filePath]: true }));
+  }
+
+  clearFolderFallback(filePath: string): void {
+    this.fallbackFolders.update((m) => {
+      const n = { ...m };
+      delete n[filePath];
+      return n;
+    });
+  }
+
+  onUnlinkClick(fileId: string): void {
+    this.unlinkFileRequested.emit(fileId);
+  }
+
+  onLinkFileClick(): void {
+    this.linkFileRequested.emit();
+  }
+}

--- a/src/app/shared/models/media.model.ts
+++ b/src/app/shared/models/media.model.ts
@@ -37,4 +37,25 @@ export interface Media {
   numberOfSeasons: number | null;
   /** Number of seasons owned in the collection (TV shows only) */
   ownedSeasonCount: number | null;
+  /** Effective root folder path — stored override or auto-derived from linked file paths. Null if no files and no override. */
+  rootFolder: string | null;
+}
+
+/** Per-season completeness data returned by GET /media/{id}/completeness */
+export interface SeasonCompleteness {
+  seasonNumber: number;
+  seasonName: string;
+  totalExpected: number;
+  ownedCount: number;
+  missingEpisodeNumbers: number[];
+  isComplete: boolean;
+}
+
+/** Unlinked MediaFile record returned by GET /admin/media/unlinked-files */
+export interface UnlinkedFile {
+  id: string;
+  filePath: string;
+  fileSizeBytes: number | null;
+  format: string | null;
+  resolution: string | null;
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -27,6 +27,7 @@
     "add": "Add",
     "back": "Back",
     "copyPath": "Copy path",
+    "copyFolderPath": "Copy folder path",
     "pathCopied": "Path copied to clipboard",
     "copyFailed": "Failed to copy path"
   },
@@ -586,12 +587,49 @@
       "reassignTmdb": "Reassign TMDB",
       "statusAll": "All",
       "statusNotAssigned": "Not Assigned",
-      "statusAssigned": "Assigned",
+      "statusAssigned": "TMDB Assigned (Pending Import)",
       "statusInCollection": "In Collection",
       "emptyMessage": "No parent folders found. Run a scan to discover TV show directories.",
       "assignDialogTitle": "Assign TMDB to {{folderName}}",
       "assignSuccess": "TMDB assigned successfully to {{folderName}}",
       "filterByStatus": "Filter by status"
+    }
+  },
+  "mediaDetail": {
+    "fileLink": {
+      "linkFileButton": "Link File",
+      "unlinkButton": "Unlink",
+      "linkSuccess": "File linked successfully",
+      "unlinkSuccess": "File unlinked successfully",
+      "linkError": "Failed to link file",
+      "unlinkError": "Failed to unlink file"
+    },
+    "filePicker": {
+      "title": "Link Unlinked File",
+      "empty": "No unlinked files available",
+      "loadError": "Failed to load unlinked files",
+      "columnPath": "File Path",
+      "columnFormat": "Format",
+      "columnSize": "Size",
+      "linkButton": "Link"
+    },
+    "rootFolder": {
+      "title": "Root Folder",
+      "copyTooltip": "Copy path to clipboard",
+      "editTooltip": "Edit root folder",
+      "empty": "No root folder set",
+      "setButton": "Set root folder",
+      "inputPlaceholder": "/nas/media/folder",
+      "saveSuccess": "Root folder saved",
+      "saveError": "Failed to save root folder"
+    },
+    "completeness": {
+      "title": "Season Completeness",
+      "noData": "Metadata not available",
+      "ownedOf": "{{owned}} / {{total}} episodes",
+      "complete": "Complete",
+      "incomplete": "Incomplete",
+      "missingEpisodes": "Missing episodes: "
     }
   },
   "a11y": {

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -27,6 +27,7 @@
     "add": "Ajouter",
     "back": "Retour",
     "copyPath": "Copier le chemin",
+    "copyFolderPath": "Copier le chemin du dossier",
     "pathCopied": "Chemin copié dans le presse-papiers",
     "copyFailed": "Échec de la copie du chemin"
   },
@@ -586,12 +587,49 @@
       "reassignTmdb": "Réassigner TMDB",
       "statusAll": "Tous",
       "statusNotAssigned": "Non assigné",
-      "statusAssigned": "Assigné",
+      "statusAssigned": "TMDB assigné (import en attente)",
       "statusInCollection": "Dans la collection",
       "emptyMessage": "Aucun dossier parent trouvé. Lancez un scan pour découvrir les répertoires de séries.",
       "assignDialogTitle": "Assigner TMDB à {{folderName}}",
       "assignSuccess": "TMDB assigné avec succès à {{folderName}}",
       "filterByStatus": "Filtrer par statut"
+    }
+  },
+  "mediaDetail": {
+    "fileLink": {
+      "linkFileButton": "Lier un fichier",
+      "unlinkButton": "Délier",
+      "linkSuccess": "Fichier lié avec succès",
+      "unlinkSuccess": "Fichier délié avec succès",
+      "linkError": "Impossible de lier le fichier",
+      "unlinkError": "Impossible de délier le fichier"
+    },
+    "filePicker": {
+      "title": "Lier un fichier non associé",
+      "empty": "Aucun fichier non associé disponible",
+      "loadError": "Impossible de charger les fichiers non associés",
+      "columnPath": "Chemin du fichier",
+      "columnFormat": "Format",
+      "columnSize": "Taille",
+      "linkButton": "Lier"
+    },
+    "rootFolder": {
+      "title": "Dossier racine",
+      "copyTooltip": "Copier le chemin",
+      "editTooltip": "Modifier le dossier racine",
+      "empty": "Aucun dossier racine défini",
+      "setButton": "Définir le dossier racine",
+      "inputPlaceholder": "/nas/media/dossier",
+      "saveSuccess": "Dossier racine enregistré",
+      "saveError": "Impossible d'enregistrer le dossier racine"
+    },
+    "completeness": {
+      "title": "Complétude des saisons",
+      "noData": "Métadonnées indisponibles",
+      "ownedOf": "{{owned}} / {{total}} épisodes",
+      "complete": "Complet",
+      "incomplete": "Incomplet",
+      "missingEpisodes": "Épisodes manquants : "
     }
   },
   "a11y": {


### PR DESCRIPTION
This pull request updates the feature directory and introduces the full Phase 1 design deliverables for the "Media File Linking & Missing Content Detection" feature (feature 007). It adds detailed planning, data model, API contracts, and specification quality checklists for the new functionality, which enables admins to link/unlink media files, manage root folders, and view completeness for TV shows. The changes do not include code, but thoroughly prepare both backend and frontend for implementation.

Key changes include:

**Documentation & Planning**

- Added a comprehensive implementation plan (`plan.md`) outlining new admin file linking/unlinking, root folder management, TV season completeness calculation, and i18n label clarifications for the parent-folder status filter.
- Introduced a specification quality checklist to ensure requirements are complete, testable, and ready for planning.

**API & Data Model Design**

- Defined new and modified API endpoints for file linking, completeness checks, and root folder management, including detailed request/response formats and error handling.
- Documented backend and frontend data model changes, including new DTOs (`SeasonCompletenessDto`, `UnlinkedFileDto`), MediatR commands/queries, and frontend service/state changes.

**Project Structure & Feature Directory**

- Updated feature directory references in `.specify/feature.json` and `.github/copilot-instructions.md` to point to the new `007-media-file-linking` spec folder. [[1]](diffhunk://#diff-f5317a02f6ff349cdecbb91b03b28a062b4aafa952fd19df5b82083988e8c623L2-R2) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L5-R5)

These changes collectively lay the groundwork for implementing robust media file linking and completeness detection features in the application.